### PR TITLE
fix: config file schema joi validator 

### DIFF
--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -13,7 +13,7 @@ const configFileSchema = Joi.object({
         schema: Joi.object().required(),
         attachments: Joi.object({
           allow: Joi.boolean().required(),
-          accept: Joi.string(),
+          accept: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.string()),
         }),
       })
     )


### PR DESCRIPTION
in this PR: 
- fixed the config file schema joi validator for attachments accept field 

now allow:
- string for single file extension.
- array for multiple file extensions 
