### PR TITLE
fix: allowing all file types as attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,9 +2261,9 @@
       }
     },
     "@govtechsg/open-attestation": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-3.8.1.tgz",
-      "integrity": "sha512-kJh/HU/9Jhta3Wb0vRaYBajC8GYWwgOFp2WJS9Qu1QzNMik2ujUc0TZf0ibswZGwO1pb4FHo9kPmNu6TIlh/rg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-3.10.0.tgz",
+      "integrity": "sha512-SN/6fbmPT1/NxSRMlPjQq37ru4V/3JOe2vU4okyEPwQcW8+bAu6P6XlNo63WQdWRgJmi0/NDRpGXOrdzA1RmBg==",
       "requires": {
         "ajv": "6.10.2",
         "debug": "^4.1.1",
@@ -2287,62 +2287,15 @@
             "uri-js": "^4.2.2"
           }
         },
-        "ethers": {
-          "version": "4.0.47",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
-          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.2",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "js-sha3": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-            },
-            "uuid": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-            }
-          }
-        },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@govtechsg/document-store": "^1.1.6",
     "@govtechsg/ethers-contract-hook": "^2.1.1",
-    "@govtechsg/open-attestation": "^3.8.1",
+    "@govtechsg/open-attestation": "^3.10.0",
     "@govtechsg/token-registry": "^1.3.0",
     "@hapi/joi": "^17.1.1",
     "ajv": "^6.12.2",

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
@@ -131,19 +131,19 @@ describe("attachmentDropzone", () => {
 
 describe("fileInfo", () => {
   it("should work for all types of files", () => {
-    expect(fileInfo("data:application/pdf;base64,JVBERi0xLjQKJdPr6eEKM")).toEqual({
+    expect(fileInfo("data:application/pdf;base64,JVBERi0xLjQKJdPr6eEKM")).toStrictEqual({
       type: "application/pdf",
       data: "JVBERi0xLjQKJdPr6eEKM",
     });
-    expect(fileInfo("data:application/zip;base64,UEsDBBQAAgAIAKB47VBTBq")).toEqual({
+    expect(fileInfo("data:application/zip;base64,UEsDBBQAAgAIAKB47VBTBq")).toStrictEqual({
       type: "application/zip",
       data: "UEsDBBQAAgAIAKB47VBTBq",
     });
-    expect(fileInfo("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAADawA")).toEqual({
+    expect(fileInfo("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAADawA")).toStrictEqual({
       type: "image/png",
       data: "iVBORw0KGgoAAAANSUhEUgAADawA",
     });
-    expect(fileInfo("data:application/octet-stream;base64,ewogICJzY2hlb")).toEqual({
+    expect(fileInfo("data:application/octet-stream;base64,ewogICJzY2hlb")).toStrictEqual({
       type: "application/octet-stream",
       data: "ewogICJzY2hlb",
     });

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
@@ -130,7 +130,7 @@ describe("attachmentDropzone", () => {
 });
 
 describe("fileInfo", () => {
-  it("works for all types of files", () => {
+  it("should work for all types of files", () => {
     expect(fileInfo("data:application/pdf;base64,JVBERi0xLjQKJdPr6eEKM")).toEqual({
       type: "application/pdf",
       data: "JVBERi0xLjQKJdPr6eEKM",
@@ -147,5 +147,10 @@ describe("fileInfo", () => {
       type: "application/octet-stream",
       data: "ewogICJzY2hlb",
     });
+  });
+  it("should throw for malformed file data", () => {
+    expect(() => fileInfo("data:application/octet-stream:base64:ewogICJzY2hlb")).toThrow(
+      /File data cannot be read/
+    );
   });
 });

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, wait } from "@testing-library/react";
 import React from "react";
-import { AttachmentDropzone } from "./AttachmentDropzone";
+import { AttachmentDropzone, fileInfo } from "./AttachmentDropzone";
 
 const mockData = (files: File[]): any => {
   return {
@@ -125,6 +125,27 @@ describe("attachmentDropzone", () => {
     await act(async () => {
       fireEvent(dropzone, event);
       await wait(() => expect(screen.getByTestId("file-size-error")).not.toBeUndefined());
+    });
+  });
+});
+
+describe("fileInfo", () => {
+  it("works for all types of files", () => {
+    expect(fileInfo("data:application/pdf;base64,JVBERi0xLjQKJdPr6eEKM")).toEqual({
+      type: "application/pdf",
+      data: "JVBERi0xLjQKJdPr6eEKM",
+    });
+    expect(fileInfo("data:application/zip;base64,UEsDBBQAAgAIAKB47VBTBq")).toEqual({
+      type: "application/zip",
+      data: "UEsDBBQAAgAIAKB47VBTBq",
+    });
+    expect(fileInfo("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAADawA")).toEqual({
+      type: "image/png",
+      data: "iVBORw0KGgoAAAANSUhEUgAADawA",
+    });
+    expect(fileInfo("data:application/octet-stream;base64,ewogICJzY2hlb")).toEqual({
+      type: "application/octet-stream",
+      data: "ewogICJzY2hlb",
     });
   });
 });

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
@@ -109,7 +109,7 @@ export const AttachmentDropzone: FunctionComponent<AttachmentDropzone> = ({
 export const fileInfo = (dataUrl: string): { type: string; data: string } => {
   const result = dataUrl.match(/^data:(.+);base64,(.*)/);
   if (!result) throw new Error(`File data cannot be read: ${dataUrl}`);
-  const [_match, type, data] = result;
+  const [, type, data] = result;
   return {
     type,
     data,

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
@@ -30,7 +30,7 @@ export const AttachmentDropzone: FunctionComponent<AttachmentDropzone> = ({
           )
         : 0;
 
-      files.reduce((acc: number, current: File) => (totalSize += current.size), 0);
+      files.forEach((file) => (totalSize += file.size));
 
       if (totalSize > MAX_FILE_SIZE) return setFileSizeError(true);
 
@@ -106,22 +106,29 @@ export const AttachmentDropzone: FunctionComponent<AttachmentDropzone> = ({
   );
 };
 
+export const fileInfo = (dataUrl: string): { type: string; data: string } => {
+  const result = dataUrl.match(/^data:(.+);base64,(.*)/);
+  if (!result) throw new Error(`File data cannot be read: ${dataUrl}`);
+  const [_match, type, data] = result;
+  return {
+    type,
+    data,
+  };
+};
+
 const processFiles = (file: File): Promise<FileUploadType> => {
-  const { name, type } = file;
+  const { name } = file;
   return new Promise((resolve, reject) => {
     const reader = new window.FileReader();
     reader.onerror = reject;
     reader.onload = (event) => {
+      const { data, type } = fileInfo(event?.target?.result as string);
       resolve({
-        data: extractBase64(event?.target?.result as string, type),
+        data,
         filename: name,
         type,
       });
     };
     reader.readAsDataURL(file);
   });
-};
-
-const extractBase64 = (dataURL: string, type: string): string => {
-  return dataURL.replace(`data:${type};base64,`, "");
 };


### PR DESCRIPTION
## Allow any type of files to be attached as attachment

Story: https://www.pivotaltracker.com/story/show/174033395

To replicate problem:

1. Drop a .tt or .opencert file as an attachment into existing creator app.
2. The application should crash and show a white screen.

The fix is two parts:

1. Remove schema restriction at OA level (and upgrading the OA dependencies)
2. Change how file types are derived, instead of using the browser File object's type (which shows up empty for files with extensions like .tt or .opencerts), we extract the file type from the FileReader's result string instead. 