### PR TITLE
fix: memory allocation for qrCodeObject that is returning the wrong value if 2 or more calls are called

### DIFF
--- a/src/common/hook/usePublishQueue/utils/publish.tsx
+++ b/src/common/hook/usePublishQueue/utils/publish.tsx
@@ -11,8 +11,6 @@ import {
 import { getQueueNumber } from "../../../API/storageAPI";
 import { encodeQrCode } from "../../../utils";
 
-const QR_CODE_OBJECT = { links: { self: { href: "" } } };
-
 interface QueueNumberTypes {
   id: string;
   key: string;
@@ -46,9 +44,15 @@ const getReservedStorageUrl = async (
     },
   };
 
-  QR_CODE_OBJECT.links.self.href = encodeQrCode(qrUrlObj);
+  const qrCodeObject = {
+    links: {
+      self: {
+        href: encodeQrCode(qrUrlObj),
+      },
+    },
+  };
 
-  return QR_CODE_OBJECT;
+  return qrCodeObject;
 };
 
 export const getRawDocuments = async (


### PR DESCRIPTION
in this PR:
- Fixed the issue where the memory allocation for the qrCodeObject is wrong, when trying to issue 2 or more documents.
This caused the document to have the same, latest, queue number which later when uploading the document will upload 2 documents into the same url, which is wrong. 