### PR TITLE
Feat/add error boundary

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
+
+export default {
+  title: "ErrorBoundaryContent",
+  component: ErrorBoundaryContent,
+  parameters: {
+    info: { inline: true, header: false },
+  },
+};
+
+export const Default = () => (
+  <ErrorBoundaryContent
+    error={
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua. Morbi tristique senectus et netus. Odio morbi quis commodo odioaenean. Mauris sit amet massa vitae tortor condimentum lacinia quis vel. Ac odio tempor orcidapibus ultrices in iaculis. In hac habitasse platea dictumst vestibulum."
+    }
+  />
+);

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react";
+import { render, screen } from "@testing-library/react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+const ErrorComponent: FunctionComponent = () => {
+  throw new Error("Intentionally throws error");
+};
+
+describe("errorboundary", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.spyOn(console, "error").mockRestore();
+  });
+
+  it("should calls getLogger and renders that there was a problem", () => {
+    expect.assertions(2);
+    render(
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId("error-boundary-content")).toBeInTheDocument();
+
+    // by mocking out console.error we may inadvertantly be missing out on logs
+    // in the future that could be important, so let's reduce that liklihood by
+    // adding an assertion for how frequently console.error is called.
+    expect(console.error).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -16,17 +16,12 @@ describe("errorboundary", () => {
   });
 
   it("should calls getLogger and renders that there was a problem", () => {
-    expect.assertions(2);
+    expect.assertions(1);
     render(
       <ErrorBoundary>
         <ErrorComponent />
       </ErrorBoundary>
     );
     expect(screen.getByTestId("error-boundary-content")).toBeInTheDocument();
-
-    // by mocking out console.error we may inadvertantly be missing out on logs
-    // in the future that could be important, so let's reduce that liklihood by
-    // adding an assertion for how frequently console.error is called.
-    expect(console.error).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import React, { Component, ReactNode } from "react";
+import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
+import { getLogger } from "../../utils/logger";
+
+const { error: errorLogger } = getLogger("component:errorboundary");
+
+type State = { hasError: boolean; error?: Error };
+
+export class ErrorBoundary extends Component<unknown, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error): void {
+    errorLogger(error);
+  }
+
+  render(): ReactNode {
+    const error = this.state.error;
+    console.log(error);
+
+    return this.state.hasError ? (
+      <ErrorBoundaryContent error={error?.stack} />
+    ) : (
+      this.props.children
+    );
+  }
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { Component, ReactNode } from "react";
 import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
 import { getLogger } from "../../utils/logger";
 
-const { error: errorLogger } = getLogger("component:errorboundary");
+const { stack } = getLogger("component:errorboundary");
 
 type State = { hasError: boolean; error?: Error };
 
@@ -14,13 +14,11 @@ export class ErrorBoundary extends Component<unknown, State> {
   }
 
   componentDidCatch(error: Error): void {
-    errorLogger(error);
+    stack(error);
   }
 
   render(): ReactNode {
     const error = this.state.error;
-    console.log(error);
-
     return this.state.hasError ? (
       <ErrorBoundaryContent error={error?.stack} />
     ) : (

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -11,7 +11,7 @@ export const ErrorBoundaryContent: FunctionComponent<{
     className="flex min-h-screen min-w-screen items-center justify-center"
     data-testid="error-boundary-content"
   >
-    <div className="container max-w-screen-md">
+    <div className="container max-w-screen-sm">
       <img
         style={{ width: 120, height: "auto" }}
         className="mb-6"

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -7,7 +7,10 @@ import { CodeBlock } from "../UI/CodeBlock";
 export const ErrorBoundaryContent: FunctionComponent<{
   error?: string;
 }> = ({ error }) => (
-  <div className="flex min-h-screen min-w-screen items-center justify-center">
+  <div
+    className="flex min-h-screen min-w-screen items-center justify-center"
+    data-testid="error-boundary-content"
+  >
     <div className="container max-w-screen-md">
       <img
         style={{ width: 120, height: "auto" }}

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent } from "react";
+import logo from "../NavigationBar/logo.svg";
+import { Title } from "../UI/Title";
+import { Button } from "../UI/Button";
+import { CodeBlock } from "../UI/CodeBlock";
+
+export const ErrorBoundaryContent: FunctionComponent<{
+  error?: string;
+}> = ({ error }) => (
+  <div className="flex min-h-screen min-w-screen items-center justify-center">
+    <div className="container max-w-screen-md">
+      <img
+        style={{ width: 120, height: "auto" }}
+        className="mb-6"
+        src={logo}
+        alt="TradeTrust Logo"
+      />
+      <Title className="mb-6">Oops...something went wrong</Title>
+      <div className="mb-2">TradeTrust has encountered an issue.</div>
+      <div>We are sorry, please</div>
+      <ol className="mb-2">
+        <li>1. Either contact the person who set up the configuration file, or</li>
+        <li>
+          2. If the issue is not with configuration, do file an issue on our{" "}
+          <a
+            className="text-blue cursor-pointer"
+            href="https://github.com/TradeTrust/document-creator-website/issues/new"
+          >
+            github repository
+          </a>
+        </li>
+      </ol>
+      {error && (
+        <div className="mb-6">
+          <CodeBlock code={error} />
+        </div>
+      )}
+      <Button
+        className="bg-orange text-white py-3 px-4"
+        data-testid="form-logout-button"
+        onClick={() => window.location.reload()}
+      >
+        Reload Application
+      </Button>
+    </div>
+  </div>
+);

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,1 @@
+export * from "./ErrorBoundary";

--- a/src/components/UI/CodeBlock/CodeBlock.stories.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { CodeBlock } from "./CodeBlock";
+
+export default {
+  title: "UI/CodeBlock",
+  component: CodeBlock,
+  parameters: {
+    componentSubtitle: "CodeBlock to show Error stack if application crashes.",
+  },
+};
+
+export const Default = () => <CodeBlock code="Error Trace Stack!" />;

--- a/src/components/UI/CodeBlock/CodeBlock.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.tsx
@@ -10,6 +10,7 @@ const CodeBlockWrap = styled.div`
   height: 160px;
   position: relative;
   overflow-y: scroll;
+  border-radius: ${vars.buttonRadius};
 
   svg {
     color: ${vars.blue};

--- a/src/components/UI/CodeBlock/CodeBlock.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.tsx
@@ -35,15 +35,15 @@ export const CodeBlock: React.FunctionComponent<CodeBlockProps> = ({ code }: Cod
   const copyToClipboard = (): void => {
     const str = document.getElementById("copy-textarea")?.innerText || "";
     // Needs to be input element to copy so created a temp
-    const $temp = document.createElement("textarea");
-    $temp.value = str;
-    $temp.setAttribute("readonly", "");
-    $temp.style.position = "absolute";
-    $temp.style.left = "-9999px";
-    document.body.appendChild($temp);
-    $temp.select();
+    const temporaryDomElement = document.createElement("textarea");
+    temporaryDomElement.value = str;
+    temporaryDomElement.setAttribute("readonly", "");
+    temporaryDomElement.style.position = "absolute";
+    temporaryDomElement.style.left = "-9999px";
+    document.body.appendChild(temporaryDomElement);
+    temporaryDomElement.select();
     document.execCommand("copy");
-    document.body.removeChild($temp);
+    document.body.removeChild(temporaryDomElement);
   };
 
   return (

--- a/src/components/UI/CodeBlock/CodeBlock.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { vars } from "../../../styles";
+import { SvgIcon, SvgIconCopy } from "../SvgIcon";
+
+const CodeBlockWrap = styled.div`
+  background-color: ${vars.blueLighter};
+  color: ${vars.greyDark};
+  padding: 16px;
+  height: 160px;
+  position: relative;
+  overflow-y: scroll;
+
+  svg {
+    color: ${vars.blue};
+    cursor: pointer;
+
+    &:hover {
+      color: ${vars.blueDark};
+    }
+  }
+
+  .copy-icon {
+    bottom: 16px;
+    right: 16px;
+  }
+`;
+
+interface CodeBlockProps {
+  code: string;
+}
+
+export const CodeBlock: React.FunctionComponent<CodeBlockProps> = ({ code }: CodeBlockProps) => {
+  const copyToClipboard = (): void => {
+    const str = document.getElementById("copy-textarea")?.innerText || "";
+    // Needs to be input element to copy so created a temp
+    const $temp = document.createElement("textarea");
+    $temp.value = str;
+    $temp.setAttribute("readonly", "");
+    $temp.style.position = "absolute";
+    $temp.style.left = "-9999px";
+    document.body.appendChild($temp);
+    $temp.select();
+    document.execCommand("copy");
+    document.body.removeChild($temp);
+  };
+
+  return (
+    <CodeBlockWrap>
+      <p className="mb-0" id="copy-textarea">
+        {code}
+      </p>
+      <div className="absolute copy-icon">
+        <SvgIcon onClick={copyToClipboard}>
+          <SvgIconCopy />
+        </SvgIcon>
+      </div>
+    </CodeBlockWrap>
+  );
+};

--- a/src/components/UI/CodeBlock/index.tsx
+++ b/src/components/UI/CodeBlock/index.tsx
@@ -1,0 +1,1 @@
+export * from "./CodeBlock";

--- a/src/components/UI/SvgIcon/SvgIcon.tsx
+++ b/src/components/UI/SvgIcon/SvgIcon.tsx
@@ -136,3 +136,12 @@ export const SvgIconLeftArrowBracket: FunctionComponent = () => {
     </g>
   );
 };
+
+export const SvgIconCopy: FunctionComponent = () => {
+  return (
+    <g className="copy">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </g>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,14 +6,17 @@ import "./index.css";
 import { App } from "./App";
 import { ConfigContextProvider } from "./common/context/config";
 import { FormsContextProvider } from "./common/context/forms";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 ReactDOM.render(
   <React.StrictMode>
-    <ConfigContextProvider>
-      <FormsContextProvider>
-        <App />
-      </FormsContextProvider>
-    </ConfigContextProvider>
+    <ErrorBoundary>
+      <ConfigContextProvider>
+        <FormsContextProvider>
+          <App />
+        </FormsContextProvider>
+      </ConfigContextProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
This PR adds an error boundary to catch uncaught javascript errors that may be thrown by app. Previously, a blank screen will be shown, now it will show the ErrorBoundary Page.