### PR TITLE
fix: e2e run headless

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "integration:headless": "HEADLESS=true ./scripts/integration.sh",
     "integration:internal": "testcafe chrome integration/**/*.spec.ts --ts-config-path ./tsconfig.testcafe.json --app \"BROWSER=none npm run start\"",
     "integration:internal:headless": "testcafe chrome:headless integration/**/*.spec.ts --ts-config-path ./tsconfig.testcafe.json --app \"npm run start\" --app-init-delay 5000",
-    "integration:concurrently:headless": "concurrently -k -s first \"npm:blockchain\" \"npm:integration\"",
+    "integration:concurrently:headless": "concurrently -k -s first \"npm:blockchain\" \"npm:integration:headless\"",
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
     "start": "npm-run-all -p start:*",


### PR DESCRIPTION
### pr updates
- think e2e currently is not running headless mode on ci