### PR TITLE
feat: update text on the home page before and after drop config file

### DIFF
--- a/integration/document-preview.spec.ts
+++ b/integration/document-preview.spec.ts
@@ -15,7 +15,7 @@ const IframeRoot = Selector("#root");
 test("Preview form with data", async (t) => {
   // upload config and reset config file
   await loadConfigFile(Config);
-  await t.expect(Title.textContent).contains("Login with Password");
+  await t.expect(Title.textContent).contains("Create Document");
 
   // login to step 1
   await t.selectText(PasswordField);

--- a/integration/integration-config-error.spec.ts
+++ b/integration/integration-config-error.spec.ts
@@ -23,7 +23,11 @@ test("Upload configuration file with error to test the errors", async (t) => {
 
   // upload config and reset config file
   await loadConfigFile(Config);
-  await t.expect(Title.textContent).contains("Login with Password");
+  await t.expect(Title.textContent).contains("Create Document");
+  await t.expect(Selector("[data-testid='login-title']").textContent).contains("Login");
   await t.click(ButtonReset);
-  await t.expect(Title.textContent).contains("Upload Configuration File");
+  await t.expect(Title.textContent).contains("Create Document");
+  await t
+    .expect(Selector("[data-testid='home-description']").textContent)
+    .contains("Drag and drop your configuration file here");
 });

--- a/integration/integration-end-to-end.spec.ts
+++ b/integration/integration-end-to-end.spec.ts
@@ -34,7 +34,8 @@ test("Upload configuration file, choose form, fill form, submit form correctly",
 
   // Upload config file
   await loadConfigFile(Config);
-  await t.expect(Title.textContent).contains("Login with Password");
+  await t.expect(Title.textContent).contains("Create Document");
+  await t.expect(Selector("[data-testid='login-title']").textContent).contains("Login");
 
   // Check if on correct network
   await t.expect(Selector("[data-testid='network-bar']").withText("Local network").exists).ok();

--- a/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.test.tsx
+++ b/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.test.tsx
@@ -22,8 +22,8 @@ const createFileTransferEvent = (files: File[]) => {
 describe("configFileDropZone", () => {
   it("should have the right text", () => {
     render(<ConfigFileDropZone onConfigFile={() => {}} />);
-    expect(screen.queryByText(/Upload Configuration File/)).not.toBeNull();
-    expect(screen.queryByText(/drop file here/)).not.toBeNull();
+    expect(screen.queryByText(/Create Document/)).not.toBeNull();
+    expect(screen.queryByText(/Drag and drop your configuration file here/)).not.toBeNull();
   });
 
   it("should allow onConfigFile to be called with dropped JSON file", async () => {

--- a/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.tsx
+++ b/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.tsx
@@ -41,7 +41,7 @@ export const ConfigFileDropZone: FunctionComponent<ConfigFileDropZone> = ({
 
   return (
     <>
-      <Title className="mb-8">Upload Configuration File</Title>
+      <Title className="mb-8">Create Document</Title>
       <div {...getRootProps()}>
         <input data-testid="config-file-drop-zone" {...getInputProps()} />
         <div className={dropZoneCSS}>
@@ -59,13 +59,15 @@ export const ConfigFileDropZone: FunctionComponent<ConfigFileDropZone> = ({
             </div>
           )}
           {!errorMessage && !error && (
-            <div className="font-bold text-lg text-grey-dark">Drag and drop file here</div>
+            <div className="font-bold text-lg text-grey-dark" data-testid="home-description">
+              Drag and drop your configuration file here
+            </div>
           )}
           <div className="text-base text-grey-dark my-4">
             {errorMessage || error ? "Please try again." : "or"}
           </div>
           <Button className="py-3 px-12 bg-white text-orange hover:text-orange-dark border border-solid border-grey-lighter">
-            Browse File
+            Browse Files
           </Button>
         </div>
       </div>

--- a/src/components/Home/WalletDecryption/WalletDecryption.test.tsx
+++ b/src/components/Home/WalletDecryption/WalletDecryption.test.tsx
@@ -65,4 +65,19 @@ describe("walletDecryption", () => {
     );
     expect(screen.queryByText(/Invalid password. Please try again./)).not.toBeNull();
   });
+
+  it("should display the correct text when rendered", () => {
+    expect.assertions(2);
+    render(
+      <WalletDecryption
+        isIncorrectPassword={false}
+        isDecrypting={false}
+        onDecryptConfigFile={() => {}}
+        onResetConfigFile={() => {}}
+      />
+    );
+
+    expect(screen.queryAllByText(/Create Document/)).toHaveLength(1);
+    expect(screen.queryAllByPlaceholderText(/Enter metawallet password/)).toHaveLength(1);
+  });
 });

--- a/src/components/Home/WalletDecryption/WalletDecryption.tsx
+++ b/src/components/Home/WalletDecryption/WalletDecryption.tsx
@@ -28,44 +28,44 @@ export const WalletDecryption: FunctionComponent<WalletDecryption> = ({
 
   return (
     <Wrapper>
-      <Title className="mb-8">Login with Password</Title>
-      <form className="bg-white flex rounded pt-5 pl-5 pr-4 pb-6">
-        <div className="text-grey-dark mr-4 mt-2 font-medium">Password</div>
-        <div className="w-full flex flex-col items-start">
-          <input
-            data-testid="password-field"
-            placeholder="Enter Password"
-            className={`
+      <Title className="mb-8">Create Document</Title>
+      <form className="bg-white flex flex-col rounded pt-5 pl-5 pr-4 pb-6">
+        <div className="text-grey-dark mr-4 mb-4 font-bold text-lg" data-testid="login-title">
+          Login
+        </div>
+        <input
+          data-testid="password-field"
+          placeholder="Enter metawallet password"
+          className={`
               ${inputBorderCSS}
               ${isDecrypting && "bg-grey-lighter"}
               ${!password && "italic"}
             `}
-            type="password"
-            value={password}
-            onChange={(evt) => setPassword(evt.target.value)}
-            disabled={isDecrypting}
-          />
-          {isIncorrectPassword && (
-            <div data-testid="password-field-msg" className="text-red text-sm mt-2">
-              Invalid password. Please try again.
-            </div>
-          )}
-          <div
-            data-testid="reset-button"
-            className="text-blue font-bold mt-4 cursor-pointer"
-            onClick={onResetConfigFile}
-          >
-            Use another Config file
+          type="password"
+          value={password}
+          onChange={(evt) => setPassword(evt.target.value)}
+          disabled={isDecrypting}
+        />
+        {isIncorrectPassword && (
+          <div data-testid="password-field-msg" className="text-red text-sm mt-2">
+            Invalid password. Please try again.
           </div>
-          <Button
-            data-testid="login-button"
-            className="bg-orange text-white self-end py-3 px-4 mt-4"
-            onClick={onLogin}
-            disabled={isDecrypting}
-          >
-            Login
-          </Button>
+        )}
+        <div
+          data-testid="reset-button"
+          className="text-blue font-bold mt-4 cursor-pointer"
+          onClick={onResetConfigFile}
+        >
+          Upload new Config file
         </div>
+        <Button
+          data-testid="login-button"
+          className="bg-orange text-white self-end py-3 px-4 mt-4"
+          onClick={onLogin}
+          disabled={isDecrypting}
+        >
+          Login
+        </Button>
       </form>
     </Wrapper>
   );


### PR DESCRIPTION
# in this PR:

- updated text on the home page
    - before user drop the config file
- updated text on the login page
- updated integration test cases
- update unit test cases

### updated screens
<img width="661" alt="Screenshot 2020-10-01 at 4 22 55 PM" src="https://user-images.githubusercontent.com/28627909/94785523-5eb07380-0402-11eb-9c50-3e07db55efc7.png">
<img width="512" alt="Screenshot 2020-10-01 at 4 23 08 PM" src="https://user-images.githubusercontent.com/28627909/94785553-66701800-0402-11eb-8aaa-45a344d19e7e.png">
