### PR TITLE
fix: update formData persisting bug and update token registry to v2 in sample-config

### DIFF
--- a/src/components/DynamicFormContainer/DynamicFormContainer.tsx
+++ b/src/components/DynamicFormContainer/DynamicFormContainer.tsx
@@ -1,12 +1,20 @@
 import React, { FunctionComponent } from "react";
 import { Redirect } from "react-router";
 import { useConfigContext } from "../../common/context/config";
+import { useFormsContext } from "../../common/context/forms";
 import { NavigationBar } from "../NavigationBar";
 import { DynamicFormLayout } from "./DynamicFormLayout";
 
 export const DynamicFormContainer: FunctionComponent = () => {
   const { config, setConfig } = useConfigContext();
-  const logout = (): void => setConfig(undefined);
+  const { setForms, setActiveFormIndex } = useFormsContext();
+
+  const logout = (): void => {
+    setForms([]);
+    setActiveFormIndex(undefined);
+    setConfig(undefined);
+  };
+
   if (!config) {
     return <Redirect to="/" />;
   }

--- a/src/test/fixtures/sample-config.json
+++ b/src/test/fixtures/sample-config.json
@@ -434,7 +434,7 @@
               "location": "demo-tradetrust.openattestation.com"
             },
             "name": "DEMO STORE",
-            "tokenRegistry": "0x10E936e6BA85dC92505760259881167141365821"
+            "tokenRegistry": "0x13249BA1Ec6B957Eb35D34D7b9fE5D91dF225B5B"
           }
         ],
         "name": "Maersk Bill of Lading"


### PR DESCRIPTION
In this PR:

- Update the token registry in the sample-config to use token registry v2
- Fixed a bug where when user logout the previous form data is still stored in the state.