### PR TITLE
fix: file icons import

### DIFF
--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.tsx
@@ -2,6 +2,12 @@ import prettyBytes from "pretty-bytes";
 import React, { FunctionComponent } from "react";
 import { FileUploadType } from "../../../../../types";
 import { Paperclip, X } from "react-feather";
+import pdf from "./pdf.svg";
+import jpg from "./jpg.svg";
+import doc from "./doc.svg";
+import csv from "./csv.svg";
+import png from "./png.svg";
+import txt from "./txt.svg";
 
 interface FilesInfoType {
   filesInfo: FileUploadType[];
@@ -19,21 +25,24 @@ const ExtensionIcon: FunctionComponent<ExtensionIconProps> = ({ ...props }) => {
 export const getExtension = (mimeType: string | undefined): React.ReactNode => {
   switch (true) {
     case mimeType === "text/csv":
-      return <ExtensionIcon src="./csv.svg" data-testid="attachment-icon-csv" />;
+      return <ExtensionIcon src={csv} data-testid="attachment-icon-csv" />;
     case mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
       mimeType === "application/msword":
-      return <ExtensionIcon src="./doc.svg" data-testid="attachment-icon-doc" />;
+      return <ExtensionIcon src={doc} data-testid="attachment-icon-doc" />;
     case mimeType === "image/jpeg":
-      return <ExtensionIcon src="./jpg.svg" data-testid="attachment-icon-jpg" />;
+      return <ExtensionIcon src={jpg} data-testid="attachment-icon-jpg" />;
     case mimeType === "image/png":
-      return <ExtensionIcon src="./png.svg" data-testid="attachment-icon-png" />;
+      return <ExtensionIcon src={png} data-testid="attachment-icon-png" />;
     case mimeType === "application/pdf":
-      return <ExtensionIcon src="./pdf.svg" data-testid="attachment-icon-pdf" />;
+      return <ExtensionIcon src={pdf} data-testid="attachment-icon-pdf" />;
     case mimeType === "text/plain":
-      return <ExtensionIcon src="./txt.svg" data-testid="attachment-icon-txt" />;
+      return <ExtensionIcon src={txt} data-testid="attachment-icon-txt" />;
     default:
       return (
-        <div className="icon" data-testid={`attachment-icon-paperclip`}>
+        <div
+          className="rounded-full bg-grey-lighter h-12 w-12 flex items-center justify-center mr-2"
+          data-testid={`attachment-icon-paperclip`}
+        >
           <Paperclip />
         </div>
       );


### PR DESCRIPTION
This PR contains a fix for the file icons not appearing. 

Drag this file in to test:
[TEST.zip](https://github.com/TradeTrust/document-creator-website/files/5449053/TEST.zip)



