### PR TITLE
fix: excel file icons for xls and xlsx

### DIFF
--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.test.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.test.tsx
@@ -48,6 +48,16 @@ describe("filesInfo", () => {
               type: "text/csv",
             },
             {
+              filename: "asdfdfs.xls",
+              data: "asdfasdf",
+              type: "application/vnd.ms-excel",
+            },
+            {
+              filename: "asdfdfs.xlsx",
+              data: "asdfasdf",
+              type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            },
+            {
               filename: "asdfdfs.docx",
               data: "asdfasdf",
               type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -73,7 +83,7 @@ describe("filesInfo", () => {
       </>
     );
     expect(screen.queryByTestId("attachment-icon-pdf")).not.toBeNull();
-    expect(screen.queryByTestId("attachment-icon-csv")).not.toBeNull();
+    expect(screen.getAllByTestId("attachment-icon-csv")).toHaveLength(3);
     expect(screen.queryByTestId("attachment-icon-png")).not.toBeNull();
     expect(screen.queryByTestId("attachment-icon-txt")).not.toBeNull();
     expect(screen.getAllByTestId("attachment-icon-doc")).toHaveLength(2);

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/FilesInfo/FilesInfo.tsx
@@ -24,7 +24,9 @@ const ExtensionIcon: FunctionComponent<ExtensionIconProps> = ({ ...props }) => {
 
 export const getExtension = (mimeType: string | undefined): React.ReactNode => {
   switch (true) {
-    case mimeType === "text/csv":
+    case mimeType === "text/csv" ||
+      mimeType === "application/vnd.ms-excel" ||
+      mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
       return <ExtensionIcon src={csv} data-testid="attachment-icon-csv" />;
     case mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
       mimeType === "application/msword":


### PR DESCRIPTION
This PR contains a fix for windows computers where .csv files are read as .xls or .xlsx.