### PR TITLE
fix: standardise qr uri to have no trailing slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,5 +233,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TradeTrust/document-creator-website.git"
   }
 }

--- a/src/common/hook/usePublishQueue/utils/sample-formatted.json
+++ b/src/common/hook/usePublishQueue/utils/sample-formatted.json
@@ -22,7 +22,7 @@
       "name": "CHAFTA Certificate of Origin",
       "links": {
         "self": {
-          "href": "https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
         }
       }
     },
@@ -52,7 +52,7 @@
       "name": "Maersk Bill of Lading",
       "links": {
         "self": {
-          "href": "https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
         }
       }
     },
@@ -87,7 +87,7 @@
       "name": "CHAFTA Certificate of Origin",
       "links": {
         "self": {
-          "href": "https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
         }
       }
     },
@@ -117,7 +117,7 @@
       "name": "Maersk Bill of Lading",
       "links": {
         "self": {
-          "href": "https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
         }
       }
     },

--- a/src/common/utils.test.tsx
+++ b/src/common/utils.test.tsx
@@ -13,7 +13,7 @@ describe("encodeQrCode", () => {
     };
 
     expect(encodeQrCode(qrCode)).toStrictEqual(
-      "https://action.openattestation.com/?q=%7B%22type%22%3A%22url%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Ftesturl.com%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22test%20Site%22%7D%7D"
+      "https://action.openattestation.com?q=%7B%22type%22%3A%22url%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Ftesturl.com%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22test%20Site%22%7D%7D"
     );
   });
 });
@@ -21,7 +21,7 @@ describe("encodeQrCode", () => {
 describe("decodeQrCode", () => {
   it("decodes an action correctly", () => {
     const encodedQrCode =
-      "https://action.openattestation.com/?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
+      "https://action.openattestation.com?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
 
     const action = decodeQrCode(encodedQrCode);
     expect(action).toStrictEqual({

--- a/src/common/utils.test.tsx
+++ b/src/common/utils.test.tsx
@@ -19,12 +19,16 @@ describe("encodeQrCode", () => {
 });
 
 describe("decodeQrCode", () => {
-  it("decodes an action correctly", () => {
-    const encodedQrCode =
+  it("decodes an action correctly regardless of trailing slash", () => {
+    const encodedQrCodeSlash =
+      "https://action.openattestation.com/?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
+    const encodedQrCodeNoSlash =
       "https://action.openattestation.com?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
 
-    const action = decodeQrCode(encodedQrCode);
-    expect(action).toStrictEqual({
+    expect(decodeQrCode(encodedQrCodeSlash)).toStrictEqual({
+      uri: "https://sample.domain/document/id?q=abc#123",
+    });
+    expect(decodeQrCode(encodedQrCodeNoSlash)).toStrictEqual({
       uri: "https://sample.domain/document/id?q=abc#123",
     });
   });

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -27,10 +27,10 @@ interface QrCode {
 }
 
 export const encodeQrCode = (payload: QrCode): string =>
-  `https://action.openattestation.com/?q=${encodeURIComponent(JSON.stringify(payload))}`;
+  `https://action.openattestation.com?q=${encodeURIComponent(JSON.stringify(payload))}`;
 
 export const decodeQrCode = (qrCode: string): QrCode => {
-  const ttRegex = /https:\/\/action.openattestation.com\/\?q=(.*)/;
+  const ttRegex = /https:\/\/action.openattestation.com\/?\?q=(.*)/;
   if (!ttRegex.test(qrCode))
     throw new Error("QR Code is not formatted to TradeTrust specifications");
   const [, encodedPayload] = ttRegex.exec(qrCode);


### PR DESCRIPTION
This PR parallels https://github.com/TradeTrust/tradetrust-website/pull/263 to remove trailing slash from qr uri!