### PR TITLE
fix: duplicate react

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,6 +1,7 @@
-var path = require('path');
+const path = require("path");
 
 module.exports = function override(config) {
-  config.resolve.alias.react = path.resolve('./node_modules/react')
+  config.resolve.alias.react = path.resolve("./node_modules/react");
+  config.devtool = process.env.NODE_ENV === "production" ? false : "eval-source-map"; // https://webpack.js.org/configuration/devtool/#devtool
   return config;
-}
+};

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -2,6 +2,8 @@ const path = require("path");
 
 module.exports = function override(config) {
   config.resolve.alias.react = path.resolve("./node_modules/react");
-  config.devtool = process.env.NODE_ENV === "production" ? false : "eval-source-map"; // https://webpack.js.org/configuration/devtool/#devtool
+  if (process.env.NODE_ENV === "production") {
+    config.devtool = false; // https://webpack.js.org/configuration/devtool/#devtool
+  }
   return config;
 };

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,6 @@
+var path = require('path');
+
+module.exports = function override(config) {
+  config.resolve.alias.react = path.resolve('./node_modules/react')
+  return config;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32858,9 +32858,9 @@
       }
     },
     "react-app-rewired": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
-      "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
       "dev": true,
       "requires": {
         "semver": "^5.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32857,6 +32857,23 @@
         }
       }
     },
+    "react-app-rewired": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
+      "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "react-clientside-effect": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "patch-package": "^6.2.2",
     "postcss-cli": "^7.1.1",
     "prettier": "^2.1.2",
+    "react-app-rewired": "^2.1.6",
     "react-scripts": "4.0.0",
     "react-test-renderer": "^16.13.1",
     "tailwindcss": "^1.9.6",
@@ -90,7 +91,7 @@
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' CI=false npm-run-all -s build:css build:js",
     "build:css": "NODE_ENV=production postcss src/tailwind.css -o src/index.css",
-    "build:js": "NODE_ENV=production react-scripts build",
+    "build:js": "NODE_ENV=production react-app-rewired build",
     "commit": "git-cz",
     "commit:retry": "npm run commit -- --retry",
     "eject": "react-scripts eject",
@@ -109,11 +110,11 @@
     "serve-static": "http-server build -s -p 3000",
     "start": "npm-run-all -p start:*",
     "start:css": "NODE_ENV=production postcss src/tailwind.css -o src/index.css --watch",
-    "start:js": "sleep 2 && react-scripts start",
+    "start:js": "sleep 2 && react-app-rewired start",
     "storybook": "npm-run-all -p start:css storybook:start",
     "storybook:start": "sleep 2 && start-storybook -p 9009 -s public",
     "storybook:build": "npm run build:css && build-storybook -s public",
-    "test": "react-scripts test --env=jest-environment-jsdom-sixteen"
+    "test": "react-app-rewired test --env=jest-environment-jsdom-sixteen"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "patch-package": "^6.2.2",
     "postcss-cli": "^7.1.1",
     "prettier": "^2.1.2",
-    "react-app-rewired": "^2.1.6",
+    "react-app-rewired": "^2.1.8",
     "react-scripts": "4.0.0",
     "react-test-renderer": "^16.13.1",
     "tailwindcss": "^1.9.6",

--- a/src/components/DynamicFormContainer/BackModal/BackModal.tsx
+++ b/src/components/DynamicFormContainer/BackModal/BackModal.tsx
@@ -36,7 +36,7 @@ export const BackModal: FunctionComponent<BackModalProps> = ({
                 </Button>
                 <Button
                   data-testid="red-back-button"
-                  className="bg-red text-white hover:bg-red-600"
+                  className="bg-red text-white hover:bg-red-400"
                   onClick={backToFormSelection}
                 >
                   Back

--- a/src/components/DynamicFormContainer/DeleteModal/DeleteModal.tsx
+++ b/src/components/DynamicFormContainer/DeleteModal/DeleteModal.tsx
@@ -33,7 +33,7 @@ export const DeleteModal: FunctionComponent<DeleteModalProps> = ({
                 </Button>
                 <Button
                   data-testid="delete-button"
-                  className="text-white bg-red hover:bg-red-600"
+                  className="text-white bg-red hover:bg-red-400"
                   onClick={deleteForm}
                 >
                   Delete


### PR DESCRIPTION
- modify webpack config without ejecting
- this should prevent duplicate react from clashing when developing locally with npm link
- also want to omit source map in production build also (the file quite big 5mb~, slowing the site down quite abit)

![Screenshot 2020-11-16 at 9 59 49 AM](https://user-images.githubusercontent.com/4774314/99206628-e0176600-27f6-11eb-950b-0701a897a228.png)

<img width="694" alt="Screenshot 2020-12-18 at 5 37 12 PM" src="https://user-images.githubusercontent.com/4774314/102598929-b6d05980-4157-11eb-94ae-f9cf920c1935.png">
