### PR TITLE
feat: added custom extension for documents

### DIFF
--- a/integration/document-extension.spec.ts
+++ b/integration/document-extension.spec.ts
@@ -1,0 +1,47 @@
+import { Selector } from "testcafe";
+import { enterPassword, loadConfigFile } from "./helper";
+
+fixture("uiSchema").page`http://localhost:3000`;
+
+const Config = "./../src/test/fixtures/sample-config-local.json";
+
+const Title = Selector("h1");
+const Button = Selector("button");
+const AddNewButton = Selector("[data-testid='add-new-button']");
+const ProgressBar = Selector("[data-testid='progress-bar']");
+const SubmitButton = Selector("[data-testid='form-submit-button']");
+
+test("document should have the correct extension if specified", async (t) => {
+  // Upload config file
+  await loadConfigFile(Config);
+  await t.expect(Title.textContent).contains("Create Document");
+  await t.expect(Selector("[data-testid='login-title']").textContent).contains("Login");
+
+  // login
+  await enterPassword("password");
+  await t.expect(Title.textContent).contains("Choose Document Type to Issue");
+  await t.expect(ProgressBar.textContent).contains("Step 1/3");
+
+  // Navigate to form
+  await t.click(Button.withText("Covering Letter (DBS)"));
+  await t.expect(Title.textContent).contains("Fill and Preview Form");
+  await t.expect(ProgressBar.textContent).contains("Step 2/3");
+
+  // Add new form
+  await t.click(AddNewButton);
+
+  // Navigate to form
+  await t.click(Button.withText("Covering Letter (extension)"));
+  await t.expect(Title.textContent).contains("Fill and Preview Form");
+  await t.expect(ProgressBar.textContent).contains("Step 2/3");
+
+  // Submit
+  await t.click(SubmitButton);
+
+  // Check that the two Covering Letters are created with the correct document extensions
+  const fileName1 = "Covering Letter (DBS)-1-local.tt";
+  const fileName2 = "Covering Letter (extension)-2-local.docTest";
+  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await t.expect(Selector("div").withText(fileName1).exists).ok();
+  await t.expect(Selector("div").withText(fileName2).exists).ok();
+});

--- a/integration/ui-schema.spec.ts
+++ b/integration/ui-schema.spec.ts
@@ -52,7 +52,7 @@ test("form should render correctly according to uiSchema", async (t) => {
   await t.expect(Title.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("Step 2/3");
 
-  // // Validate that default values is populated
+  // Validate that default values is populated
   await t.expect(DocumentTitleField.value).contains("Documents Bundle");
   await t
     .expect(DocumentRemarksField.value)
@@ -63,21 +63,21 @@ test("form should render correctly according to uiSchema", async (t) => {
     .expect(Form.find("textarea#root_remarks").value)
     .contains("Some very important documents in here for some submission");
 
-  // // Add new form
+  // Add new form
   await t.click(AddNewButton);
 
-  // /*
-  //  * This test case is here in the event that users really
-  //  * want to have a `uiSchema` attribute present in their
-  //  * TradeTrust document.
-  //  */
+  /*
+   * This test case is here in the event that users really
+   * want to have a `uiSchema` attribute present in their
+   * TradeTrust document.
+   */
 
-  // // Navigate to form
+  // Navigate to form
   await t.click(Button.withText("Covering Letter (DBS, Nested UISchema)"));
   await t.expect(Title.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("Step 2/3");
 
-  // // Validate that default values is populated
+  // Validate that default values is populated
   await t.expect(DocumentTitleField.value).contains("Documents Bundle");
   await t
     .expect(DocumentRemarksField.value)

--- a/integration/ui-schema.spec.ts
+++ b/integration/ui-schema.spec.ts
@@ -1,0 +1,131 @@
+import { getData } from "@govtechsg/open-attestation";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { Selector } from "testcafe";
+import { enterPassword, loadConfigFile } from "./helper";
+
+fixture("uiSchema").page`http://localhost:3000`;
+
+const Config = "./../src/test/fixtures/sample-config-local.json";
+
+const Title = Selector("h1");
+const Button = Selector("button");
+const Form = Selector("[data-testid='form-group field field-object']");
+const AddNewButton = Selector("[data-testid='add-new-button']");
+const ProgressBar = Selector("[data-testid='progress-bar']");
+const SubmitButton = Selector("[data-testid='form-submit-button']");
+const DocumentTitleField = Selector("#root_title");
+const DocumentRemarksField = Selector("#root_remarks");
+const DownloadLink = Selector("[data-testid='download-file-button']");
+
+function getFileDownloadPath(fileName: string): string {
+  return join(homedir(), "Downloads", fileName);
+}
+
+// From https://stackoverflow.com/a/57624660/950462
+const waitForFileDownload = async (t: TestController, filePath: string): Promise<boolean> => {
+  // Timeout after 10 seconds
+  for (let i = 0; i < 100; i++) {
+    if (existsSync(filePath)) return true;
+    await t.wait(100);
+  }
+  return existsSync(filePath);
+};
+
+test("form should render correctly according to uiSchema", async (t) => {
+  // Upload config file
+  await loadConfigFile(Config);
+  await t.expect(Title.textContent).contains("Create Document");
+  await t.expect(Selector("[data-testid='login-title']").textContent).contains("Login");
+
+  // Check if on correct network
+  await t.expect(Selector("[data-testid='network-bar']").withText("Local network").exists).ok();
+
+  // login
+  await enterPassword("password");
+  await t.expect(Title.textContent).contains("Choose Document Type to Issue");
+  await t.expect(ProgressBar.textContent).contains("Step 1/3");
+
+  // Navigate to form
+  await t.click(Button.withText("Covering Letter (DBS)"));
+  await t.expect(Title.textContent).contains("Fill and Preview Form");
+  await t.expect(ProgressBar.textContent).contains("Step 2/3");
+
+  // // Validate that default values is populated
+  await t.expect(DocumentTitleField.value).contains("Documents Bundle");
+  await t
+    .expect(DocumentRemarksField.value)
+    .contains("Some very important documents in here for some submission");
+
+  // Expect uiSchema to be working, i.e. it renders the remarks field to be a textarea
+  await t
+    .expect(Form.find("textarea#root_remarks").value)
+    .contains("Some very important documents in here for some submission");
+
+  // // Add new form
+  await t.click(AddNewButton);
+
+  // /*
+  //  * This test case is here in the event that users really
+  //  * want to have a `uiSchema` attribute present in their
+  //  * TradeTrust document.
+  //  */
+
+  // // Navigate to form
+  await t.click(Button.withText("Covering Letter (DBS, Nested UISchema)"));
+  await t.expect(Title.textContent).contains("Fill and Preview Form");
+  await t.expect(ProgressBar.textContent).contains("Step 2/3");
+
+  // // Validate that default values is populated
+  await t.expect(DocumentTitleField.value).contains("Documents Bundle");
+  await t
+    .expect(DocumentRemarksField.value)
+    .contains("Some very important documents in here for some submission");
+
+  // Expect remarks field to be a normal input field (because uiSchema does not exist at the form template's root level)
+  await t
+    .expect(Form.find("input#root_remarks").value)
+    .contains("Some very important documents in here for some submission");
+
+  // Submit
+  await t.click(SubmitButton);
+
+  // pending confirmation of issued documents
+  await t.expect(Selector("[data-testid='publish-loader']").exists).ok();
+
+  // Check that the two Covering Letters are created
+  const fileName1 = "Covering Letter (DBS)-1-local.tt";
+  const fileName2 = "Covering Letter (DBS, Nested UISchema)-2-local.tt";
+  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await t.expect(Selector("div").withText(fileName1).exists).ok();
+  await t.expect(Selector("div").withText(fileName2).exists).ok();
+  await t.expect(Selector("div").withText("Download").exists).ok();
+
+  // Check that the first Covering Letter has been downloaded successfully
+  await t.click(DownloadLink.nth(0));
+  const filePath1 = getFileDownloadPath(fileName1);
+  await t.expect(await waitForFileDownload(t, filePath1)).eql(true);
+
+  // We expect the contents of the first doc to NOT contain uiSchema key
+  // Only doing a `contains` check because the value is non-deterministic due to the hash
+  const docContents1 = JSON.parse(readFileSync(filePath1, "utf8"));
+  await t.expect(docContents1.data).notContains({ uiSchema: { remarks: { "ui:widget": "" } } });
+
+  // Check that the second Covering Letter has been downloaded successfully
+  await t.click(DownloadLink.nth(1));
+  const filePath2 = getFileDownloadPath(fileName2);
+  await t.expect(await waitForFileDownload(t, filePath2)).eql(true);
+
+  // We expect the contents of the second doc to contain the uiSchema key,
+  // one at the root level, the other nested in `misc`
+  const docContents2 = JSON.parse(readFileSync(filePath2, "utf8"));
+  // Need stringify first, then parse. Without it, getData() alone's return type is never.
+  const docContentsUnwrapped2 = JSON.parse(JSON.stringify(getData({ data: docContents2.data })));
+  await t.expect(docContentsUnwrapped2.misc.uiSchema.remarks).contains({
+    "ui:widget": "textarea",
+  });
+  await t.expect(docContentsUnwrapped2.uiSchema.remarks).contains({
+    "ui:widget": "textarea",
+  });
+});

--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -16,6 +16,8 @@ const configFileSchema = Joi.object({
           accept: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.string()),
         }),
         headers: Joi.array().optional(),
+        uiSchema: Joi.object(),
+        extension: Joi.string(),
       })
     )
     .required(),

--- a/src/common/context/forms/forms.test.tsx
+++ b/src/common/context/forms/forms.test.tsx
@@ -45,6 +45,7 @@ describe("useFormsContext", () => {
         schema: "FORM_2_SCHEMA",
       },
       fileName: "Document-1",
+      extension: "tt",
       ownership: { holderAddress: "", beneficiaryAddress: "" },
     };
 
@@ -88,11 +89,13 @@ describe("useFormsContext", () => {
         },
         fileName: "Document-1",
         ownership: { holderAddress: "", beneficiaryAddress: "" },
+        extension: "tt",
       },
       {
         templateIndex: 0,
         data: { formData: { foo: "bar" } },
         fileName: "Document-2",
+        extension: "tt",
         ownership: { holderAddress: "", beneficiaryAddress: "" },
       },
       {
@@ -105,6 +108,7 @@ describe("useFormsContext", () => {
         },
         fileName: "Document-3",
         ownership: { holderAddress: "", beneficiaryAddress: "" },
+        extension: "tt",
       },
     ];
 
@@ -138,6 +142,7 @@ describe("useFormsContext", () => {
         },
         fileName: "Document-1",
         ownership: { holderAddress: "0x0Bar", beneficiaryAddress: "0x0Foo" },
+        extension: "tt",
       },
     ];
 

--- a/src/common/context/forms/index.tsx
+++ b/src/common/context/forms/index.tsx
@@ -47,6 +47,7 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
     const newIndex = forms.length;
     const newFormTemplate = config?.forms[templateIndex];
     const newFormName = newFormTemplate?.name ?? "Document";
+    const extension = config?.forms[templateIndex]?.extension ?? "tt";
     setForms([
       ...forms,
       {
@@ -57,6 +58,7 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
         },
         fileName: `${newFormName}-${forms.length + 1}`,
         ownership: { beneficiaryAddress: "", holderAddress: "" },
+        extension: extension,
       },
     ]);
     setActiveFormIndex(newIndex);
@@ -66,6 +68,7 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
     const newFormTemplate = config?.forms[templateIndex];
     const newFormName = newFormTemplate?.name ?? "Document";
     const formEntries: FormEntry[] = [];
+    const extension = config?.forms[templateIndex]?.extension ?? "tt";
     for (let index = 0; index < data.length; index++) {
       formEntries.push({
         templateIndex,
@@ -75,6 +78,7 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
         },
         fileName: data[index].fileName ?? `${newFormName}-${forms.length + 1 + index}`,
         ownership: data[index].ownership ?? { beneficiaryAddress: "", holderAddress: "" },
+        extension: extension,
       });
     }
     setForms([...forms, ...formEntries]);

--- a/src/common/hook/usePublishQueue/usePublishQueue.test.tsx
+++ b/src/common/hook/usePublishQueue/usePublishQueue.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import { getDefaultProvider, Wallet } from "ethers";
+import { PublishState } from "../../../constants/PublishState";
 import { publishJob } from "../../../services/publishing";
 import sampleConfig from "../../../test/fixtures/sample-config-ropsten.json";
 import sampleJobs from "../../../test/fixtures/sample-jobs.json";
@@ -7,7 +8,6 @@ import { Config, FormEntry } from "../../../types";
 import { uploadToStorage } from "../../API/storageAPI";
 import { usePublishQueue } from "./usePublishQueue";
 import { getPublishingJobs } from "./utils/publish";
-import { PublishState } from "../../../constants/PublishState";
 
 jest.mock("../../../services/publishing");
 jest.mock("./utils/publish");
@@ -30,6 +30,7 @@ const formEntires: FormEntry[] = [
       formData: { foo: "bar" },
     },
     ownership: { holderAddress: "", beneficiaryAddress: "" },
+    extension: "tt",
   },
   {
     fileName: "document-2",
@@ -38,6 +39,7 @@ const formEntires: FormEntry[] = [
       formData: { foo: "bar" },
     },
     ownership: { holderAddress: "", beneficiaryAddress: "" },
+    extension: "tt",
   },
 ];
 

--- a/src/common/hook/usePublishQueue/usePublishQueue.tsx
+++ b/src/common/hook/usePublishQueue/usePublishQueue.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
+import { PublishState } from "../../../constants/PublishState";
 import { publishJob } from "../../../services/publishing";
 import { Config, FailedJobErrors, FormEntry, PublishingJob, WrappedDocument } from "../../../types";
 import { getLogger } from "../../../utils/logger";
 import { uploadToStorage } from "../../API/storageAPI";
 import { getPublishingJobs } from "./utils/publish";
-import { PublishState } from "../../../constants/PublishState";
 
 const { stack } = getLogger("usePublishQueue");
 
@@ -31,10 +31,10 @@ export const usePublishQueue = (
   const [failedJob, setFailedJob] = useState<FailedJob[]>([]);
   const [pendingJobIndex, setPendingJobIndex] = useState<number[]>([]);
 
-  const publishedDocuments = completedJobIndex.reduce((acc, curr) => {
-    const documentsIssuesInJob = jobs[curr].documents;
-    return [...acc, ...documentsIssuesInJob];
-  }, [] as WrappedDocument[]);
+  const publishedDocuments = completedJobIndex.reduce(
+    (acc, curr) => [...acc, ...jobs[curr].documents],
+    [] as WrappedDocument[]
+  );
 
   const failedPublishedDocuments = failedJob.map((job) => {
     return {

--- a/src/common/hook/usePublishQueue/utils/publish.tsx
+++ b/src/common/hook/usePublishQueue/utils/publish.tsx
@@ -54,7 +54,7 @@ export const getRawDocuments = async (
   config: Config
 ): Promise<RawDocument[]> => {
   return Promise.all(
-    forms.map(async ({ data, templateIndex, fileName, ownership }) => {
+    forms.map(async ({ data, templateIndex, fileName, ownership, extension }) => {
       let qrUrl = {};
 
       if (config.network !== "local") {
@@ -77,6 +77,7 @@ export const getRawDocuments = async (
         rawDocument: formData,
         fileName,
         payload,
+        extension,
       };
     })
   );

--- a/src/common/hook/usePublishQueue/utils/sample-formatted-without-qr-url.json
+++ b/src/common/hook/usePublishQueue/utils/sample-formatted-without-qr-url.json
@@ -22,6 +22,7 @@
       "name": "CHAFTA Certificate of Origin"
     },
     "fileName": "Document-1.tt",
+    "extension": "tt",
     "payload": {}
   },
   {
@@ -47,6 +48,7 @@
       "name": "Maersk Bill of Lading"
     },
     "fileName": "Document-2.tt",
+    "extension": "tt",
     "payload": {
       "ownership": {
         "beneficiaryAddress": "0x81b7e08f65bdf5648606c89998a9cc8164397647",
@@ -77,6 +79,7 @@
       "name": "CHAFTA Certificate of Origin"
     },
     "fileName": "Document-3.tt",
+    "extension": "tt",
     "payload": {}
   },
   {
@@ -102,6 +105,7 @@
       "name": "Maersk Bill of Lading"
     },
     "fileName": "Document-4.tt",
+    "extension": "tt",
     "payload": {
       "ownership": {
         "beneficiaryAddress": "0x06e96617ef41a609b70d0c6dfc47f6082e6400f3",

--- a/src/common/hook/usePublishQueue/utils/sample-formatted.json
+++ b/src/common/hook/usePublishQueue/utils/sample-formatted.json
@@ -27,6 +27,7 @@
       }
     },
     "fileName": "Document-1.tt",
+    "extension": "tt",
     "payload": {}
   },
   {
@@ -57,6 +58,7 @@
       }
     },
     "fileName": "Document-2.tt",
+    "extension": "tt",
     "payload": {
       "ownership": {
         "beneficiaryAddress": "0x81b7e08f65bdf5648606c89998a9cc8164397647",
@@ -92,6 +94,7 @@
       }
     },
     "fileName": "Document-3.tt",
+    "extension": "tt",
     "payload": {}
   },
   {
@@ -122,6 +125,7 @@
       }
     },
     "fileName": "Document-4.tt",
+    "extension": "tt",
     "payload": {
       "ownership": {
         "beneficiaryAddress": "0x06e96617ef41a609b70d0c6dfc47f6082e6400f3",

--- a/src/common/hook/usePublishQueue/utils/sample-forms.json
+++ b/src/common/hook/usePublishQueue/utils/sample-forms.json
@@ -7,6 +7,7 @@
         "iD": "COO 1"
       }
     },
+    "extension": "tt",
     "ownership": {
       "beneficiaryAddress": "",
       "holderAddress": ""
@@ -20,6 +21,7 @@
         "blNumber": "BL 1"
       }
     },
+    "extension": "tt",
     "ownership": {
       "beneficiaryAddress": "0x81b7e08f65bdf5648606c89998a9cc8164397647",
       "holderAddress": "0x06e96617ef41a609b70d0c6dfc47f6082e6400f3"
@@ -33,6 +35,7 @@
         "iD": "COO 2"
       }
     },
+    "extension": "tt",
     "ownership": {
       "beneficiaryAddress": "",
       "holderAddress": ""
@@ -46,6 +49,7 @@
         "blNumber": "BL 2"
       }
     },
+    "extension": "tt",
     "ownership": {
       "beneficiaryAddress": "0x06e96617ef41a609b70d0c6dfc47f6082e6400f3",
       "holderAddress": "0x81b7e08f65bdf5648606c89998a9cc8164397647"

--- a/src/components/DynamicFormContainer/DynamicForm/DynamicForm.stories.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/DynamicForm.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent } from "react";
+import React, { FunctionComponent, useState } from "react";
 import sample from "../../../test/fixtures/sample-config-ropsten.json";
 import { ConfigFile, FormTemplate } from "../../../types";
 import { DynamicForm } from "./DynamicForm";
@@ -24,17 +24,14 @@ const defaults = {
   logo: "https://www.aretese.com/images/govtech-animated-logo.gif",
   title: "Documents Bundle",
   remarks: "Some very important documents in here for some submission",
-  uiSchema: {
-    remarks: {
-      "ui:widget": "textarea",
-    },
-  },
 };
 
 // Form values that the admin staff will be changing
 const configFile = sample as ConfigFile;
 const schema = configFile.forms[2].schema;
 const attachments = configFile.forms[2].attachments;
+const uiSchema = configFile.forms[2].uiSchema;
+const extension = configFile.forms[2].extension;
 
 const form: FormTemplate = {
   name: "Covering Letter",
@@ -42,6 +39,8 @@ const form: FormTemplate = {
   defaults,
   schema,
   attachments,
+  uiSchema,
+  extension,
 };
 
 export default {
@@ -64,6 +63,7 @@ export const Default: FunctionComponent = () => {
   return (
     <DynamicForm
       schema={form.schema}
+      uiSchema={form.uiSchema}
       form={formData}
       setFormData={setFormData}
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/components/DynamicFormContainer/DynamicForm/DynamicForm.test.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/DynamicForm.test.tsx
@@ -18,6 +18,7 @@ const commonProps = {
     data: { formData: {} },
     templateIndex: 0,
     ownership: { beneficiaryAddress: "", holderAddress: "" },
+    extension: "tt",
   },
   setFormData: mockSetFormData,
   setOwnership: mockSetOwnership,

--- a/src/components/DynamicFormContainer/DynamicForm/DynamicForm.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/DynamicForm.tsx
@@ -3,6 +3,7 @@ import { cloneDeep } from "lodash";
 import React, { FunctionComponent } from "react";
 import JsonForm from "react-jsonschema-form";
 import tw from "twin.macro";
+import { useFormsContext } from "../../../common/context/forms";
 import { mixin } from "../../../styles";
 import {
   FileUploadType,
@@ -12,8 +13,6 @@ import {
   Ownership,
   SetFormParams,
 } from "../../../types";
-
-import { useFormsContext } from "../../../common/context/forms";
 import { DataFileButton } from "../DataFileButton";
 import { TransferableRecordForm } from "../TransferableRecordForm";
 import { AttachmentDropzone } from "./AttachmentDropzone";
@@ -33,10 +32,12 @@ export interface DynamicFormProps {
   setFormData: (formData: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
   setOwnership: (ownership: Ownership) => void;
   setCurrentForm: (arg: SetFormParams) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  uiSchema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const DynamicFormRaw: FunctionComponent<DynamicFormProps> = ({
   schema,
+  uiSchema,
   form,
   setFormData,
   setOwnership,
@@ -89,8 +90,6 @@ export const DynamicFormRaw: FunctionComponent<DynamicFormProps> = ({
 
     setAttachments(nextAttachment);
   };
-
-  const uiSchema = data.formData.uiSchema || {};
 
   const widgets = {
     TextareaWidget: CustomTextareaWidget,

--- a/src/components/DynamicFormContainer/DynamicForm/DynamicForm.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/DynamicForm.tsx
@@ -32,7 +32,7 @@ export interface DynamicFormProps {
   setFormData: (formData: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
   setOwnership: (ownership: Ownership) => void;
   setCurrentForm: (arg: SetFormParams) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-  uiSchema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  uiSchema?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const DynamicFormRaw: FunctionComponent<DynamicFormProps> = ({

--- a/src/components/DynamicFormContainer/DynamicFormLayout.tsx
+++ b/src/components/DynamicFormContainer/DynamicFormLayout.tsx
@@ -35,6 +35,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
   if (isSubmitted) return <Redirect to="/publish" />;
 
   const { schema: formSchema } = currentFormTemplate;
+  const { uiSchema } = currentFormTemplate;
   const attachmentAccepted = !!currentFormTemplate.attachments?.allow;
   const attachmentAcceptedFormat = currentFormTemplate.attachments?.accept;
 
@@ -142,6 +143,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
               <div className="max-w-screen-sm mx-auto mt-6">
                 <DynamicForm
                   schema={formSchema}
+                  uiSchema={uiSchema}
                   form={currentForm}
                   type={currentFormTemplate.type}
                   setFormData={setCurrentFormData}

--- a/src/components/PublishContainer/PublishPage/PublishPage.test.tsx
+++ b/src/components/PublishContainer/PublishPage/PublishPage.test.tsx
@@ -28,12 +28,14 @@ const whenPublishStateIsConfirmed = (): void => {
     forms: [
       {
         fileName: "document-1",
+        extension: "tt",
         data: { formData: {} },
         templateIndex: 0,
       },
     ],
     currentForm: {
       fileName: "document-1",
+      extension: "tt",
       data: { formData: {} },
       templateIndex: 0,
     },
@@ -53,6 +55,7 @@ const whenPublishStateIsConfirmed = (): void => {
           signature: {},
           version: "",
         },
+        extension: "tt",
       },
     ],
     failedPublishedDocuments: [],
@@ -69,12 +72,14 @@ const whenPublishStateIsError = (): void => {
     forms: [
       {
         fileName: "document-1",
+        extension: "tt",
         data: { formData: {} },
         templateIndex: 0,
       },
     ],
     currentForm: {
       fileName: "document-1",
+      extension: "tt",
       data: { formData: {} },
       templateIndex: 0,
     },
@@ -101,12 +106,14 @@ const whenPublishStateIsPending = (): void => {
     forms: [
       {
         fileName: "document-1",
+        extension: "tt",
         data: { formData: {} },
         templateIndex: 0,
       },
     ],
     currentForm: {
       fileName: "document-1",
+      extension: "tt",
       data: { formData: {} },
       templateIndex: 0,
     },

--- a/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
@@ -5,13 +5,13 @@ import prettyBytes from "pretty-bytes";
 import React, { FunctionComponent } from "react";
 import { Download, XCircle } from "react-feather";
 import { useConfigContext } from "../../../common/context/config";
+import { PublishState } from "../../../constants/PublishState";
 import { FailedJobErrors, WrappedDocument } from "../../../types";
 import { generateFileName } from "../../../utils/fileName";
 import { ProgressBar } from "../../ProgressBar";
 import { Wrapper } from "../../UI/Wrapper";
 import { PublishedTag } from "../PublishedScreen/PublishedTag";
 import { PublishTitle } from "./PublishTitle";
-import { PublishState } from "../../../constants/PublishState";
 
 interface PublishScreen {
   publishedDocuments: WrappedDocument[];
@@ -55,7 +55,7 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
         generateFileName({
           network: config?.network,
           fileName: document.fileName,
-          extension: "tt",
+          extension: document.extension,
         }),
         blob
       );
@@ -153,7 +153,7 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
                       {generateFileName({
                         network: config?.network,
                         fileName: doc.fileName,
-                        extension: "tt",
+                        extension: doc.extension,
                       })}
                     </div>
                     <div className="text-xs text-grey ml-1">({size})</div>

--- a/src/components/PublishContainer/PublishedScreen/PublishedTag/PublishedTag.test.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedTag/PublishedTag.test.tsx
@@ -23,6 +23,7 @@ const mockDoc = {
   payload: {},
   rawDocument: {},
   wrappedDocument: { data: "test document" },
+  extension: "tt",
 } as WrappedDocument;
 
 describe("publishedTag", () => {

--- a/src/components/PublishContainer/PublishedScreen/PublishedTag/PublishedTag.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedTag/PublishedTag.tsx
@@ -1,7 +1,7 @@
+import { LoaderSpinner } from "@govtechsg/tradetrust-ui-components";
 import { saveAs } from "file-saver";
 import prettyBytes from "pretty-bytes";
 import React, { FunctionComponent } from "react";
-import { LoaderSpinner } from "@govtechsg/tradetrust-ui-components";
 import { useConfigContext } from "../../../../common/context/config";
 import { WrappedDocument } from "../../../../types";
 import { generateFileName } from "../../../../utils/fileName";
@@ -24,7 +24,7 @@ export const PublishedTag: FunctionComponent<PublishedTagProps> = ({ doc, isPend
   const fileName = generateFileName({
     network: config?.network,
     fileName: doc.fileName,
-    extension: "tt",
+    extension: doc.extension,
   });
   return (
     <div className="mt-4 flex rounded bg-white p-3 min-w-xs max-w-xs border border-solid border-grey-200 mr-4 items-center">

--- a/src/test/fixtures/sample-config-local.json
+++ b/src/test/fixtures/sample-config-local.json
@@ -589,6 +589,112 @@
         "allow": true
       },
       "headers": ["title", "remarks"]
+    },
+    {
+      "name": "Covering Letter (DBS)",
+      "type": "VERIFIABLE_DOCUMENT",
+      "defaults": {
+        "$template": {
+          "type": "EMBEDDED_RENDERER",
+          "name": "COVERING_LETTER",
+          "url": "https://generic-templates.tradetrust.io"
+        },
+        "issuers": [
+          {
+            "name": "Demo Issuer",
+            "documentStore": "0x63a223e025256790e88778a01f480eba77731d04",
+            "identityProof": {
+              "type": "DNS-TXT",
+              "location": "demo-tradetrust.openattestation.com"
+            }
+          }
+        ],
+        "name": "Covering Letter",
+        "logo": "https://pluspng.com/img-png/logo-dbs-png-file-dbs-bank-logo-svg-1280.png",
+        "backgroundColor": "black",
+        "titleColor": "white",
+        "remarksColor": "white",
+        "title": "Documents Bundle",
+        "remarks": "Some very important documents in here for some submission"
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Document Title"
+          },
+          "remarks": {
+            "type": "string",
+            "title": "Remarks"
+          }
+        }
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
+      },
+      "attachments": {
+        "allow": true
+      }
+    },
+    {
+      "name": "Covering Letter (DBS, Nested UISchema)",
+      "type": "VERIFIABLE_DOCUMENT",
+      "defaults": {
+        "$template": {
+          "type": "EMBEDDED_RENDERER",
+          "name": "COVERING_LETTER",
+          "url": "https://generic-templates.tradetrust.io"
+        },
+        "issuers": [
+          {
+            "name": "Demo Issuer",
+            "documentStore": "0x63a223e025256790e88778a01f480eba77731d04",
+            "identityProof": {
+              "type": "DNS-TXT",
+              "location": "demo-tradetrust.openattestation.com"
+            }
+          }
+        ],
+        "name": "Covering Letter",
+        "logo": "https://pluspng.com/img-png/logo-dbs-png-file-dbs-bank-logo-svg-1280.png",
+        "backgroundColor": "black",
+        "titleColor": "white",
+        "remarksColor": "white",
+        "title": "Documents Bundle",
+        "remarks": "Some very important documents in here for some submission",
+        "misc": {
+          "miscKey1": "miscValue1",
+          "uiSchema": {
+            "remarks": {
+              "ui:widget": "textarea"
+            }
+          }
+        },
+        "uiSchema": {
+          "remarks": {
+            "ui:widget": "textarea"
+          }
+        }
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Document Title"
+          },
+          "remarks": {
+            "type": "string",
+            "title": "Remarks"
+          }
+        }
+      },
+      "attachments": {
+        "allow": true
+      }
     }
   ]
 }

--- a/src/test/fixtures/sample-config-local.json
+++ b/src/test/fixtures/sample-config-local.json
@@ -708,7 +708,7 @@
         "issuers": [
           {
             "name": "Demo Issuer",
-            "documentStore": "0x63a223e025256790e88778a01f480eba77731d04",
+            "documentStore": "0x8bA63EAB43342AAc3AdBB4B827b68Cf4aAE5Caca",
             "identityProof": {
               "type": "DNS-TXT",
               "location": "demo-tradetrust.openattestation.com"

--- a/src/test/fixtures/sample-config-local.json
+++ b/src/test/fixtures/sample-config-local.json
@@ -565,11 +565,11 @@
         ],
         "name": "Covering Letter",
         "title": "Default Value",
-        "remarks": "Default Value",
-        "uiSchema": {
-          "remarks": {
-            "ui:widget": "textarea"
-          }
+        "remarks": "Default Value"
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
         }
       },
       "schema": {
@@ -695,6 +695,53 @@
       "attachments": {
         "allow": true
       }
+    },
+    {
+      "name": "Covering Letter (extension)",
+      "type": "VERIFIABLE_DOCUMENT",
+      "defaults": {
+        "$template": {
+          "type": "EMBEDDED_RENDERER",
+          "name": "COVERING_LETTER",
+          "url": "https://generic-templates.tradetrust.io"
+        },
+        "issuers": [
+          {
+            "name": "Demo Issuer",
+            "documentStore": "0x63a223e025256790e88778a01f480eba77731d04",
+            "identityProof": {
+              "type": "DNS-TXT",
+              "location": "demo-tradetrust.openattestation.com"
+            }
+          }
+        ],
+        "name": "Covering Letter",
+        "title": "Default Value",
+        "remarks": "Default Value"
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
+      },
+      "extension": "docTest",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Document Title"
+          },
+          "remarks": {
+            "type": "string",
+            "title": "Remarks"
+          }
+        }
+      },
+      "attachments": {
+        "allow": true
+      },
+      "headers": ["title", "remarks"]
     }
   ]
 }

--- a/src/test/fixtures/sample-config-rinkeby.json
+++ b/src/test/fixtures/sample-config-rinkeby.json
@@ -422,7 +422,8 @@
       "attachments": {
         "allow": true,
         "accept": ".pdf"
-      }
+      },
+      "extension": "test"
     },
     {
       "name": "Bill of Lading",
@@ -542,7 +543,8 @@
       "attachments": {
         "allow": true,
         "accept": ".pdf, .json"
-      }
+      },
+      "extension": "test"
     },
     {
       "name": "Covering Letter (GT)",
@@ -566,12 +568,7 @@
         "name": "Covering Letter",
         "logo": "https://www.aretese.com/images/govtech-animated-logo.gif",
         "title": "Documents Bundle",
-        "remarks": "Some very important documents in here for some submission",
-        "uiSchema": {
-          "remarks": {
-            "ui:widget": "textarea"
-          }
-        }
+        "remarks": "Some very important documents in here for some submission"
       },
       "schema": {
         "type": "object",
@@ -588,7 +585,13 @@
       },
       "attachments": {
         "allow": true
-      }
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
+      },
+      "extension": "test"
     },
     {
       "name": "Covering Letter (DBS)",
@@ -615,12 +618,7 @@
         "titleColor": "white",
         "remarksColor": "white",
         "title": "Documents Bundle",
-        "remarks": "Some very important documents in here for some submission",
-        "uiSchema": {
-          "remarks": {
-            "ui:widget": "textarea"
-          }
-        }
+        "remarks": "Some very important documents in here for some submission"
       },
       "schema": {
         "type": "object",
@@ -637,7 +635,13 @@
       },
       "attachments": {
         "allow": true
-      }
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
+      },
+      "extension": "test"
     },
     {
       "name": "Invoice (IMDA)",
@@ -787,7 +791,8 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "extension": "test"
     }
   ],
   "documentStorage": {

--- a/src/test/fixtures/sample-config-rinkeby.json
+++ b/src/test/fixtures/sample-config-rinkeby.json
@@ -423,7 +423,7 @@
         "allow": true,
         "accept": ".pdf"
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Bill of Lading",
@@ -544,7 +544,7 @@
         "allow": true,
         "accept": ".pdf, .json"
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Covering Letter (GT)",
@@ -591,7 +591,7 @@
           "ui:widget": "textarea"
         }
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Covering Letter (DBS)",
@@ -641,7 +641,7 @@
           "ui:widget": "textarea"
         }
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Invoice (IMDA)",
@@ -792,7 +792,7 @@
           }
         }
       },
-      "extension": "test"
+      "extension": "tt"
     }
   ],
   "documentStorage": {

--- a/src/test/fixtures/sample-config-ropsten.json
+++ b/src/test/fixtures/sample-config-ropsten.json
@@ -423,7 +423,7 @@
         "allow": true,
         "accept": ".pdf"
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Bill of Lading",
@@ -544,7 +544,7 @@
         "allow": true,
         "accept": ".pdf, .json"
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Covering Letter (GT)",
@@ -591,7 +591,7 @@
           "ui:widget": "textarea"
         }
       },
-      "extension": "test"
+      "extension": "tt"
     },
     {
       "name": "Covering Letter (DBS)",
@@ -791,7 +791,7 @@
           }
         }
       },
-      "extension": "test"
+      "extension": "tt"
     }
   ],
   "documentStorage": {

--- a/src/test/fixtures/sample-config-ropsten.json
+++ b/src/test/fixtures/sample-config-ropsten.json
@@ -422,7 +422,8 @@
       "attachments": {
         "allow": true,
         "accept": ".pdf"
-      }
+      },
+      "extension": "test"
     },
     {
       "name": "Bill of Lading",
@@ -542,7 +543,8 @@
       "attachments": {
         "allow": true,
         "accept": ".pdf, .json"
-      }
+      },
+      "extension": "test"
     },
     {
       "name": "Covering Letter (GT)",
@@ -566,12 +568,7 @@
         "name": "Covering Letter",
         "logo": "https://www.aretese.com/images/govtech-animated-logo.gif",
         "title": "Documents Bundle",
-        "remarks": "Some very important documents in here for some submission",
-        "uiSchema": {
-          "remarks": {
-            "ui:widget": "textarea"
-          }
-        }
+        "remarks": "Some very important documents in here for some submission"
       },
       "schema": {
         "type": "object",
@@ -588,7 +585,13 @@
       },
       "attachments": {
         "allow": true
-      }
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
+      },
+      "extension": "test"
     },
     {
       "name": "Covering Letter (DBS)",
@@ -615,12 +618,7 @@
         "titleColor": "white",
         "remarksColor": "white",
         "title": "Documents Bundle",
-        "remarks": "Some very important documents in here for some submission",
-        "uiSchema": {
-          "remarks": {
-            "ui:widget": "textarea"
-          }
-        }
+        "remarks": "Some very important documents in here for some submission"
       },
       "schema": {
         "type": "object",
@@ -637,6 +635,11 @@
       },
       "attachments": {
         "allow": true
+      },
+      "uiSchema": {
+        "remarks": {
+          "ui:widget": "textarea"
+        }
       }
     },
     {
@@ -787,7 +790,8 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "extension": "test"
     }
   ],
   "documentStorage": {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,6 +11,8 @@ export interface FormTemplate {
   schema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   attachments?: Attachments;
   headers?: string[];
+  uiSchema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  extension: string;
 }
 
 export interface DocumentStorage {
@@ -65,6 +67,7 @@ export interface FormEntry {
   data: FormData;
   templateIndex: number;
   ownership: Ownership;
+  extension: string;
 }
 
 export interface SetFormParams {
@@ -79,6 +82,7 @@ export interface RawDocument {
   rawDocument: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   fileName: string;
   payload: { ownership?: Ownership };
+  extension: string;
 }
 
 export interface WrappedDocument extends RawDocument {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -67,7 +67,7 @@ export interface FormEntry {
   data: FormData;
   templateIndex: number;
   ownership: Ownership;
-  extension?: string;
+  extension: string;
 }
 
 export interface SetFormParams {
@@ -82,7 +82,7 @@ export interface RawDocument {
   rawDocument: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   fileName: string;
   payload: { ownership?: Ownership };
-  extension?: string;
+  extension: string;
 }
 
 export interface WrappedDocument extends RawDocument {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,8 +11,8 @@ export interface FormTemplate {
   schema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   attachments?: Attachments;
   headers?: string[];
-  uiSchema: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  extension: string;
+  uiSchema?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  extension?: string;
 }
 
 export interface DocumentStorage {
@@ -67,7 +67,7 @@ export interface FormEntry {
   data: FormData;
   templateIndex: number;
   ownership: Ownership;
-  extension: string;
+  extension?: string;
 }
 
 export interface SetFormParams {
@@ -82,7 +82,7 @@ export interface RawDocument {
   rawDocument: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   fileName: string;
   payload: { ownership?: Ownership };
-  extension: string;
+  extension?: string;
 }
 
 export interface WrappedDocument extends RawDocument {


### PR DESCRIPTION
# In this PR:
- Refactor uiSchema to be outside defaults (from here: https://github.com/TradeTrust/document-creator-website/pull/62/files)
- Add document extension into the config file so that user can customise the generated documents.
- By default it will fall back to ".tt" if the user didn't specify any file extension.