### PR TITLE
fix: added awskms algorithm type

### DIFF
--- a/src/common/config/decrypt.tsx
+++ b/src/common/config/decrypt.tsx
@@ -1,5 +1,5 @@
 import { Wallet, getDefaultProvider, providers } from "ethers";
-import { AwsKmsAlgorithmType, AwsKmwSignerOption, ConfigFile, ConnectedSigner } from "../../types";
+import { AwsKmwSignerOption, ConfigFile, ConnectedSigner } from "../../types";
 import { RelayProvider } from "@opengsn/gsn";
 import { getGSNRelayConfig, getHttpProviderUri } from "../../config";
 import Web3HttpProvider from "web3-providers-http";

--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -6,6 +6,7 @@ const configFileSchema = Joi.object({
   wallet: Joi.alternatives(
     Joi.string().required(),
     Joi.object().keys({
+      type: Joi.string().valid("ECC_SECG_P256K1").required,
       accessKeyId: Joi.string().required(),
       region: Joi.string().required(),
       kmsKeyId: Joi.string().required(),

--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -6,7 +6,7 @@ const configFileSchema = Joi.object({
   wallet: Joi.alternatives(
     Joi.string().required(),
     Joi.object().keys({
-      type: Joi.string().valid("ECC_SECG_P256K1").required,
+      type: Joi.string().valid("ECC_SECG_P256K1").required(),
       accessKeyId: Joi.string().required(),
       region: Joi.string().required(),
       kmsKeyId: Joi.string().required(),

--- a/src/test/fixtures/sample-config-ropsten-aws.json
+++ b/src/test/fixtures/sample-config-ropsten-aws.json
@@ -1,9 +1,10 @@
 {
   "network": "ropsten",
   "wallet": {
-    "accessKeyId": "<access key id>",
-    "region": "<region>",
-    "kmsKeyId": "<kms key id>"
+    "type": "ECC_SECG_P256K1",
+    "accessKeyId": "AKIAXTJ7ZOXXNOKYUSUU",
+    "region": "ap-southeast-1",
+    "kmsKeyId": "arn:aws:kms:ap-southeast-1:522509186542:key/237caa94-84d2-4f7d-9403-a119a82f54e2"
   },
   "forms": [
     {
@@ -18,10 +19,10 @@
         "issuers": [
           {
             "name": "Demo Issuer",
-            "documentStore": "0x6e80FD3dD1151607Ce15B98eE1e3DDd4E4DdF0B6",
+            "documentStore": "0xAa2BaF74bD975526025Ae5EfAF08798Dd2856107",
             "identityProof": {
               "type": "DNS-TXT",
-              "location": "example.openattestation.com"
+              "location": "siachenren.mywork.business"
             }
           }
         ],
@@ -442,10 +443,10 @@
           {
             "identityProof": {
               "type": "DNS-TXT",
-              "location": "example.tradetrust.io"
+              "location": "siachenren.mywork.business"
             },
             "name": "DEMO TOKEN REGISTRY",
-            "tokenRegistry": "0x039F02729e64fa77128C334F3685AFbd1f22DB96"
+            "tokenRegistry": "0x8a09d9860C7259009242b66F42849f137b5ab209"
           }
         ]
       },
@@ -562,10 +563,10 @@
         "issuers": [
           {
             "name": "Demo Issuer",
-            "documentStore": "0x6e80FD3dD1151607Ce15B98eE1e3DDd4E4DdF0B6",
+            "documentStore": "0xAa2BaF74bD975526025Ae5EfAF08798Dd2856107",
             "identityProof": {
               "type": "DNS-TXT",
-              "location": "example.openattestation.com"
+              "location": "siachenren.mywork.business"
             }
           }
         ],
@@ -609,10 +610,10 @@
         "issuers": [
           {
             "name": "Demo Issuer",
-            "documentStore": "0x6e80FD3dD1151607Ce15B98eE1e3DDd4E4DdF0B6",
+            "documentStore": "0xAa2BaF74bD975526025Ae5EfAF08798Dd2856107",
             "identityProof": {
               "type": "DNS-TXT",
-              "location": "example.openattestation.comm"
+              "location": "siachenren.mywork.business"
             }
           }
         ],

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,6 +3,7 @@ import { Provider } from "@ethersproject/abstract-provider";
 
 type Network = "homestead" | "ropsten" | "rinkeby" | "local";
 type FormType = "TRANSFERABLE_RECORD" | "VERIFIABLE_DOCUMENT";
+type AwsKmsAlgorithmType = "ECC_SECG_P256K1";
 
 // FormTemplate is defined in configuration file
 export interface FormTemplate {
@@ -23,6 +24,7 @@ export interface DocumentStorage {
 }
 
 export type AwsKmwSignerOption = {
+  type: AwsKmsAlgorithmType;
   accessKeyId: string;
   region: string;
   kmsKeyId: string;


### PR DESCRIPTION
Added type for future expansion when taking in different awskms algorithm.
In the current situation, we only support "ECC_SECG_P256K1" type.