### PR TITLE
fix: e2e flakes

### DIFF
--- a/integration/document-extension.spec.ts
+++ b/integration/document-extension.spec.ts
@@ -42,8 +42,7 @@ test("should have the correct extension if specified", async (t) => {
   // Check that the two Covering Letters are created with the correct document extensions
   const fileName1 = "Covering Letter (DBS)-1-local.tt";
   const fileName2 = "Covering Letter (extension)-2-local.docTest";
-  await processTitle.with({ visibilityCheck: true })();
-  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
+  await t.expect(processTitle.withText("Document(s) issued successfully").exists).ok();
   await t.expect(Selector("div").withText(fileName1).exists).ok();
   await t.expect(Selector("div").withText(fileName2).exists).ok();
 });

--- a/integration/document-extension.spec.ts
+++ b/integration/document-extension.spec.ts
@@ -6,6 +6,7 @@ fixture("Document extension").page`http://localhost:3000`;
 const Config = "./../src/test/fixtures/sample-config-local.json";
 
 const Title = Selector("h1");
+const processTitle = Selector("[data-testid='process-title']");
 const Button = Selector("button");
 const AddNewButton = Selector("[data-testid='add-new-button']");
 const ProgressBar = Selector("[data-testid='progress-bar']");
@@ -41,7 +42,8 @@ test("should have the correct extension if specified", async (t) => {
   // Check that the two Covering Letters are created with the correct document extensions
   const fileName1 = "Covering Letter (DBS)-1-local.tt";
   const fileName2 = "Covering Letter (extension)-2-local.docTest";
-  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await processTitle.with({ visibilityCheck: true })();
+  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
   await t.expect(Selector("div").withText(fileName1).exists).ok();
   await t.expect(Selector("div").withText(fileName2).exists).ok();
 });

--- a/integration/happy-flow.spec.ts
+++ b/integration/happy-flow.spec.ts
@@ -9,6 +9,7 @@ const DataFileEbl = "./../src/test/fixtures/sample-data-file-ebl.json";
 const DataFileCsvEbl = "./../src/test/fixtures/sample-data-file-ebl.csv";
 
 const Title = Selector("h1");
+const processTitle = Selector("[data-testid='process-title']");
 const Button = Selector("button");
 const ProgressBar = Selector("[data-testid='progress-bar']");
 const SubmitButton = Selector("[data-testid='form-submit-button']");
@@ -60,7 +61,8 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.expect(Selector("[data-testid='processing-loader']").exists).ok();
 
   // Check that download exists
-  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await processTitle.with({ visibilityCheck: true })();
+  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
   await t.expect(Selector("div").withText("COO-1-local.tt").exists).ok();
   await t.expect(Selector("div").withText("Download").exists).ok();
   await t.expect(DownloadAllButton.exists).ok();
@@ -102,7 +104,8 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.click(SubmitButton);
 
   // Check that EBL is created
-  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await processTitle.with({ visibilityCheck: true })();
+  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
   await t.expect(Selector("div").withText("bill-123-local.tt").exists).ok();
   await t.expect(Selector("div").withText("bill-<blNumber 1>-local.tt").exists).ok();
   await t.expect(Selector("div").withText("bill-<blNumber 2>-local.tt").exists).ok();

--- a/integration/happy-flow.spec.ts
+++ b/integration/happy-flow.spec.ts
@@ -61,8 +61,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.expect(Selector("[data-testid='processing-loader']").exists).ok();
 
   // Check that download exists
-  await processTitle.with({ visibilityCheck: true })();
-  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
+  await t.expect(processTitle.withText("Document(s) issued successfully").exists).ok();
   await t.expect(Selector("div").withText("COO-1-local.tt").exists).ok();
   await t.expect(Selector("div").withText("Download").exists).ok();
   await t.expect(DownloadAllButton.exists).ok();
@@ -104,8 +103,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.click(SubmitButton);
 
   // Check that EBL is created
-  await processTitle.with({ visibilityCheck: true })();
-  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
+  await t.expect(processTitle.withText("Document(s) issued successfully").exists).ok();
   await t.expect(Selector("div").withText("bill-123-local.tt").exists).ok();
   await t.expect(Selector("div").withText("bill-<blNumber 1>-local.tt").exists).ok();
   await t.expect(Selector("div").withText("bill-<blNumber 2>-local.tt").exists).ok();

--- a/integration/ui-schema.spec.ts
+++ b/integration/ui-schema.spec.ts
@@ -93,8 +93,7 @@ test("form should render correctly according to uiSchema", async (t) => {
   // Check that the two Covering Letters are created
   const fileName1 = "Covering Letter (DBS)-1-local.tt";
   const fileName2 = "Covering Letter (DBS, Nested UISchema)-2-local.tt";
-  await processTitle.with({ visibilityCheck: true })();
-  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
+  await t.expect(processTitle.withText("Document(s) issued successfully").exists).ok();
   await t.expect(Selector("div").withText(fileName1).exists).ok();
   await t.expect(Selector("div").withText(fileName2).exists).ok();
   await t.expect(Selector("div").withText("Download").exists).ok();

--- a/integration/ui-schema.spec.ts
+++ b/integration/ui-schema.spec.ts
@@ -9,6 +9,7 @@ fixture("uiSchema").page`http://localhost:3000`;
 const Config = "./../src/test/fixtures/sample-config-local.json";
 
 const Title = Selector("h1");
+const processTitle = Selector("[data-testid='process-title']");
 const Button = Selector("button");
 const Form = Selector("[data-testid='form-group field field-object']");
 const AddNewButton = Selector("[data-testid='add-new-button']");
@@ -92,7 +93,8 @@ test("form should render correctly according to uiSchema", async (t) => {
   // Check that the two Covering Letters are created
   const fileName1 = "Covering Letter (DBS)-1-local.tt";
   const fileName2 = "Covering Letter (DBS, Nested UISchema)-2-local.tt";
-  await t.expect(Title.textContent).contains("Document(s) issued successfully");
+  await processTitle.with({ visibilityCheck: true })();
+  await t.expect(processTitle.textContent).contains("Document(s) issued successfully");
   await t.expect(Selector("div").withText(fileName1).exists).ok();
   await t.expect(Selector("div").withText(fileName2).exists).ok();
   await t.expect(Selector("div").withText("Download").exists).ok();

--- a/src/components/ProcessDocumentScreen/ProcessDocumentScreen.test.tsx
+++ b/src/components/ProcessDocumentScreen/ProcessDocumentScreen.test.tsx
@@ -135,7 +135,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.ISSUE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Please wait while we prepare your document(s)");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Please wait while we prepare your document(s)");
   });
 
   it("should display the correct title while initialise with revoke flow", () => {
@@ -149,7 +149,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.REVOKE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Please wait while we prepare your document(s)");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Please wait while we prepare your document(s)");
   });
 
   it("should display the correct title while pending issuing", () => {
@@ -162,7 +162,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.ISSUE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Publishing document(s)...");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Publishing document(s)...");
   });
 
   it("should display the correct title while pending revoke", () => {
@@ -176,7 +176,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.REVOKE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Revoking document(s)...");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Revoking document(s)...");
   });
 
   it("should display the correct title when document issue successfully", () => {
@@ -189,7 +189,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.ISSUE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Document(s) issued successfully");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Document(s) issued successfully");
   });
 
   it("should display the correct title when document revoke successfully", () => {
@@ -203,7 +203,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.REVOKE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Document(s) revoked successfully");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Document(s) revoked successfully");
   });
 
   it("should display the correct title when document has error", () => {
@@ -243,7 +243,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.ISSUE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Document(s) failed to issue");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Document(s) failed to issue");
     expect(screen.getByTestId("error-message")).toHaveTextContent(
       "These documents failed to publish due to some errors. Kindly rectify and try publishing again."
     );
@@ -260,7 +260,7 @@ describe("ProcessDocumentScreen", () => {
         type={QueueType.REVOKE}
       />
     );
-    expect(screen.getByTestId("title")).toHaveTextContent("Document(s) failed to revoke");
+    expect(screen.getByTestId("process-title")).toHaveTextContent("Document(s) failed to revoke");
     expect(screen.getByTestId("error-message")).toHaveTextContent(
       "These documents failed to publish due to some errors. Kindly rectify and try publishing again."
     );

--- a/src/components/ProcessDocumentScreen/ProcessDocumentTitle/ProcessDocumentTitle.tsx
+++ b/src/components/ProcessDocumentScreen/ProcessDocumentTitle/ProcessDocumentTitle.tsx
@@ -13,13 +13,18 @@ interface ProcessDocumentTitle {
 
 export const ProcessDocumentTitle: FunctionComponent<ProcessDocumentTitle> = ({ queueState, documents, type }) => {
   const isIssuingFlow = type === QueueType.ISSUE;
+
+  const titleText = (message: string): ReactElement => {
+    return <span data-testid="process-title">{message}</span>;
+  };
+
   const getDisplayTitle = (): ReactElement => {
     switch (queueState) {
       case QueueState.PENDING:
         return (
           <>
             <LoaderSpinner className="mr-2" width="24px" primary="#00cbbc" secondary="#e2e8f0" />
-            {`${isIssuingFlow ? "Publishing " : "Revoking"} document(s)...`}
+            {titleText(`${isIssuingFlow ? "Publishing " : "Revoking"} document(s)...`)}
           </>
         );
 
@@ -27,28 +32,24 @@ export const ProcessDocumentTitle: FunctionComponent<ProcessDocumentTitle> = ({ 
         if (documents.length > 0) {
           return (
             <>
-              <CheckCircle className="mr-2 text-emerald" />
-              {`Document(s) ${isIssuingFlow ? "issued" : "revoked"} successfully`}
+              <CheckCircle className="mr-2 text-teal-300" />
+              {titleText(`Document(s) ${isIssuingFlow ? "issued" : "revoked"} successfully`)}
             </>
           );
         } else {
           return (
             <>
               <XCircle className="mr-2 text-rose" />
-              {`Document(s) failed to ${isIssuingFlow ? "issue" : "revoke"}`}
+              {titleText(`Document(s) failed to ${isIssuingFlow ? "issue" : "revoke"}`)}
             </>
           );
         }
 
       case QueueState.INITIALIZED:
       default:
-        return <>Please wait while we prepare your document(s)</>;
+        return titleText(`Please wait while we prepare your document(s)`);
     }
   };
 
-  return (
-    <Title className="flex items-center mb-8" data-testid="process-title">
-      {getDisplayTitle()}
-    </Title>
-  );
+  return <Title className="flex items-center mb-8">{getDisplayTitle()}</Title>;
 };

--- a/src/components/ProcessDocumentScreen/ProcessDocumentTitle/ProcessDocumentTitle.tsx
+++ b/src/components/ProcessDocumentScreen/ProcessDocumentTitle/ProcessDocumentTitle.tsx
@@ -47,7 +47,7 @@ export const ProcessDocumentTitle: FunctionComponent<ProcessDocumentTitle> = ({ 
   };
 
   return (
-    <Title className="flex items-center mb-8" data-testid="title">
+    <Title className="flex items-center mb-8" data-testid="process-title">
       {getDisplayTitle()}
     </Title>
   );


### PR DESCRIPTION
- tests flakes at a particular assertion
  - assign a dedicated `testid`, instead of generic `h1` in case of race to incorrect selector
  - ~~await visibility, before assert~~
  - assert with `withText("foobar").exists.ok()` instead
- not sure if will help, needs monitoring thereafter

![ui-schema](https://user-images.githubusercontent.com/4774314/130917424-e5730362-3c62-4659-8272-28ea44fb4a2c.png)

![document-extension](https://user-images.githubusercontent.com/4774314/130917441-884fe615-5f0e-43c1-af85-8c821fb5c93a.png)
