### PR TITLE
fix: flakes

### DIFF
--- a/integration/happy-flow.spec.ts
+++ b/integration/happy-flow.spec.ts
@@ -63,7 +63,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
 
   // Check that download exists
   await t.expect(Selector("div").withText("COO-1-local.tt").exists).ok();
-  await t.expect(Selector("div").withText("Download").exists).ok();
+  await t.expect(Selector("[data-testid='download-file-button']").withText("Download").exists).ok();
   await t.expect(DownloadAllButton.exists).ok();
 
   // Issue transferable record

--- a/integration/revoke-document.spec.ts
+++ b/integration/revoke-document.spec.ts
@@ -38,6 +38,6 @@ test("should revoke a document on local blockchain correctly", async (t) => {
   await t.click(Selector("[data-testid='revoke-button']"));
   await t.expect(Selector("[data-testid='modal-title']").textContent).contains("Revoke Document");
   await t.click(Selector("[data-testid='modal-revoke-button']"));
-  await t.expect(ProcessDocumentTitle.textContent).contains("Document revoked successfully");
+  await t.expect(ProcessDocumentTitle.withText("Document revoked successfully").exists).ok();
   await t.expect(Selector("[data-testid='file-name']").textContent).contains("wrapped-document-local-revokable.json");
 });


### PR DESCRIPTION
- https://testcafe.io/documentation/402837/guides/basic-guides/assert#smart-assertion-query-mechanism
- maybe we should avoid potential problematic asserts and start asserting on other static parts instead, yet preserving the test's intent i guess