### PR TITLE
fix: rename form name

### DIFF
--- a/integration/buttons.spec.ts
+++ b/integration/buttons.spec.ts
@@ -25,7 +25,7 @@ test("should lead to pages correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Covering Letter"));
+  await t.click(Button.withText("TradeTrust Covering Letter v2"));
 
   // Check back button
   await t.click(ButtonClearAll);

--- a/integration/custom-array-field-ordering.spec.ts
+++ b/integration/custom-array-field-ordering.spec.ts
@@ -14,7 +14,7 @@ const Remove0 = Selector(`[data-testid="custom-array-field-0"] [data-testid="rem
 test("should add, order, remove correctly", async (t) => {
   await loadConfigFile(configRopsten);
   await enterPassword("password");
-  await t.click(Selector("button").withText("Invoice"));
+  await t.click(Selector("button").withText("TradeTrust Invoice v2"));
 
   await t.click(AddItem);
   await t.typeText(Desc0, "foobar");

--- a/integration/document-attachments.spec.ts
+++ b/integration/document-attachments.spec.ts
@@ -25,7 +25,7 @@ test("should be added and removed correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Covering Letter"));
+  await t.click(Button.withText("TradeTrust Covering Letter v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/integration/document-data-upload-error.spec.ts
+++ b/integration/document-data-upload-error.spec.ts
@@ -24,7 +24,7 @@ test("should show validation error messages correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Bill of Lading"));
+  await t.click(Button.withText("TradeTrust Bill of Lading v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/integration/document-data-upload.spec.ts
+++ b/integration/document-data-upload.spec.ts
@@ -58,7 +58,7 @@ test("should upload populate data fields correctly for version 2 document", asyn
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -81,15 +81,15 @@ test("should upload populate data fields correctly for version 2 document", asyn
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCoo]);
 
   // Validated the content is overwritten by the data file
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-2");
   await t.expect(V2COOiDField.value).eql("SampleId-1");
   await t.expect(V2COOIssueDateTimeField.value).eql("2015-01-01T00:00:00.000");
 
   // Check next document
   await t.typeText(documentNumberInput, "3", { replace: true });
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-3");
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-3");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-3");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-3");
   await t.expect(V2COOiDField.value).eql("SampleId-2");
   await t.expect(V2COOIssueDateTimeField.value).eql("2015-01-02T00:00:00.000");
 });
@@ -105,7 +105,7 @@ test("should upload populate data fields correctly for version 3 document", asyn
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v3"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v3"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -129,15 +129,15 @@ test("should upload populate data fields correctly for version 3 document", asyn
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCooV3]);
 
   // Validated the content is overwritten by the data file
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-2");
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v3-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v3-2");
   await t.expect(V3COOiDField.value).eql("SampleId-1");
   await t.expect(V3COOIssueDateTimeField.value).eql("2021-01-01T00:00:00.000");
 
   // Check next document
   await t.typeText(documentNumberInput, "3", { replace: true });
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-3");
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-3");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v3-3");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v3-3");
   await t.expect(V3COOiDField.value).eql("SampleId-2");
   await t.expect(V3COOIssueDateTimeField.value).eql("2021-02-01T00:00:00.000");
 });

--- a/integration/document-data-upload.spec.ts
+++ b/integration/document-data-upload.spec.ts
@@ -58,7 +58,7 @@ test("should upload populate data fields correctly for version 2 document", asyn
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -81,15 +81,15 @@ test("should upload populate data fields correctly for version 2 document", asyn
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCoo]);
 
   // Validated the content is overwritten by the data file
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-2");
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
   await t.expect(V2COOiDField.value).eql("SampleId-1");
   await t.expect(V2COOIssueDateTimeField.value).eql("2015-01-01T00:00:00.000");
 
   // Check next document
   await t.typeText(documentNumberInput, "3", { replace: true });
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-3");
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-3");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-3");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-3");
   await t.expect(V2COOiDField.value).eql("SampleId-2");
   await t.expect(V2COOIssueDateTimeField.value).eql("2015-01-02T00:00:00.000");
 });
@@ -105,7 +105,7 @@ test("should upload populate data fields correctly for version 3 document", asyn
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)").nth(1));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v3"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -129,15 +129,15 @@ test("should upload populate data fields correctly for version 3 document", asyn
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCooV3]);
 
   // Validated the content is overwritten by the data file
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-2");
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-2");
   await t.expect(V3COOiDField.value).eql("SampleId-1");
   await t.expect(V3COOIssueDateTimeField.value).eql("2021-01-01T00:00:00.000");
 
   // Check next document
   await t.typeText(documentNumberInput, "3", { replace: true });
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-3");
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-3");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-3");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v3-3");
   await t.expect(V3COOiDField.value).eql("SampleId-2");
   await t.expect(V3COOIssueDateTimeField.value).eql("2021-02-01T00:00:00.000");
 });

--- a/integration/document-extension.spec.ts
+++ b/integration/document-extension.spec.ts
@@ -23,7 +23,7 @@ test("should have the correct extension if specified", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Covering Letter"));
+  await t.click(Button.withText("TradeTrust Covering Letter v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -39,7 +39,7 @@ test("should have the correct extension if specified", async (t) => {
   await t.click(SubmitButton);
 
   // Check that the two Covering Letters are created with the correct document extensions
-  const fileName1 = "Covering Letter-1-local.tt";
+  const fileName1 = "TradeTrust Covering Letter v2-1-local.tt";
   const fileName2 = "Covering Letter (extension)-2-local.docTest";
   await t.expect(Selector("div").withText(fileName1).exists).ok();
   await t.expect(Selector("div").withText(fileName2).exists).ok();

--- a/integration/document-preview.spec.ts
+++ b/integration/document-preview.spec.ts
@@ -24,7 +24,7 @@ test("should be able to preview form with data", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/integration/document-preview.spec.ts
+++ b/integration/document-preview.spec.ts
@@ -24,7 +24,7 @@ test("should be able to preview form with data", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/integration/document-rename.spec.ts
+++ b/integration/document-rename.spec.ts
@@ -26,7 +26,7 @@ test("should rename document filename correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -34,16 +34,16 @@ test("should rename document filename correctly", async (t) => {
   await t.click(AddNewButton);
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.typeText(FormIdField, "COO-ID");
 
   // Go to the previous document
   await t.typeText(documentNumberInput, "1", { replace: true });
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-1");
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-1");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-1");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-1");
 
   // Go back to the other document
   await t.typeText(documentNumberInput, "2", { replace: true });
-  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
-  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-ChAFTA-Certificate-of-Origin-v2-2");
 });

--- a/integration/document-rename.spec.ts
+++ b/integration/document-rename.spec.ts
@@ -26,7 +26,7 @@ test("should rename document filename correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -34,16 +34,16 @@ test("should rename document filename correctly", async (t) => {
   await t.click(AddNewButton);
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.typeText(FormIdField, "COO-ID");
 
   // Go to the previous document
   await t.typeText(documentNumberInput, "1", { replace: true });
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-1");
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-1");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-1");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-1");
 
   // Go back to the other document
   await t.typeText(documentNumberInput, "2", { replace: true });
-  await t.expect(fileNameField.value).eql("COO-(ChAFTA)-2");
-  await t.expect(documentNameSelect.innerText).eql("COO-(ChAFTA)-2");
+  await t.expect(fileNameField.value).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
+  await t.expect(documentNameSelect.innerText).eql("TradeTrust-Chafa-Certificate-of-Origin-v2-2");
 });

--- a/integration/error-attachment-limit.spec.ts
+++ b/integration/error-attachment-limit.spec.ts
@@ -23,7 +23,7 @@ test("should show file limit warning when over 6mb", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.typeText(FormIdField, "COO-ID");
 
   // Upload a attachment (over file limit)

--- a/integration/error-attachment-limit.spec.ts
+++ b/integration/error-attachment-limit.spec.ts
@@ -23,7 +23,7 @@ test("should show file limit warning when over 6mb", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.typeText(FormIdField, "COO-ID");
 
   // Upload a attachment (over file limit)

--- a/integration/error-document-issue.spec.ts
+++ b/integration/error-document-issue.spec.ts
@@ -21,7 +21,7 @@ test("should show failed published document(s) errors", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Covering Letter"));
+  await t.click(Button.withText("TradeTrust Covering Letter v2"));
 
   // Submit form
   await t.click(SubmitButton);
@@ -30,5 +30,5 @@ test("should show failed published document(s) errors", async (t) => {
   await t.expect(ProcessDocumentTitle.textContent).contains("Document(s) failed to issue");
   await t.expect(Selector("div").withText("1 document(s)").exists).ok();
   await t.expect(Selector("div").withText("The document(s) could not be issued at this time.").exists).ok();
-  await t.expect(Selector("div").withText("Covering Letter-1-local.tt").exists).ok();
+  await t.expect(Selector("div").withText("TradeTrust Covering Letter v2-1-local.tt").exists).ok();
 });

--- a/integration/happy-flow.spec.ts
+++ b/integration/happy-flow.spec.ts
@@ -31,7 +31,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
+  await t.click(Button.withText("TradeTrust ChAFTA Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/integration/happy-flow.spec.ts
+++ b/integration/happy-flow.spec.ts
@@ -31,7 +31,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("COO (ChAFTA)"));
+  await t.click(Button.withText("TradeTrust Chafa Certificate of Origin v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 
@@ -57,7 +57,7 @@ test("should issue the documents on local blockchain correctly", async (t) => {
 
   // Issue transferable record
   await t.click(Button.withText("Create Another Document"));
-  await t.click(Button.withText("Bill of Lading"));
+  await t.click(Button.withText("TradeTrust Bill of Lading v2"));
 
   // Fill in form
   await t.typeText(EblBeneficiaryField, "0x6FFeD6E6591b808130a9b248fEA32101b5220eca");

--- a/integration/ui-schema.spec.ts
+++ b/integration/ui-schema.spec.ts
@@ -25,7 +25,7 @@ test("form should render remarks as custom textarea when uiSchema exists", async
   await t.expect(ProgressBar.textContent).contains("1");
 
   // Navigate to form
-  await t.click(Button.withText("Covering Letter"));
+  await t.click(Button.withText("TradeTrust Covering Letter v2"));
   await t.expect(FillFormTitle.textContent).contains("Fill and Preview Form");
   await t.expect(ProgressBar.textContent).contains("2");
 

--- a/src/test/fixtures/config/_generated-config-files/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/sample-config-ropsten.json
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -939,7 +939,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/sample-config-ropsten.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -558,7 +558,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -642,7 +642,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -797,7 +797,7 @@
       "extension": "tt"
     },
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -939,7 +939,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1397,7 +1397,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/config-empty-wallet.json
+++ b/src/test/fixtures/config/_generated-config-files/test/config-empty-wallet.json
@@ -128,7 +128,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -1077,7 +1077,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/config-empty-wallet.json
+++ b/src/test/fixtures/config/_generated-config-files/test/config-empty-wallet.json
@@ -3,7 +3,7 @@
   "wallet": "",
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -128,7 +128,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -555,7 +555,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -639,7 +639,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -935,7 +935,7 @@
       }
     },
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1077,7 +1077,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1535,7 +1535,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/config-invalid-issuer.json
+++ b/src/test/fixtures/config/_generated-config-files/test/config-invalid-issuer.json
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -1080,7 +1080,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/config-invalid-issuer.json
+++ b/src/test/fixtures/config/_generated-config-files/test/config-invalid-issuer.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -558,7 +558,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -642,7 +642,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -938,7 +938,7 @@
       }
     },
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1080,7 +1080,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1538,7 +1538,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/sample-config-local.json
+++ b/src/test/fixtures/config/_generated-config-files/test/sample-config-local.json
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -1080,7 +1080,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/test/sample-config-local.json
+++ b/src/test/fixtures/config/_generated-config-files/test/sample-config-local.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -558,7 +558,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -642,7 +642,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -938,7 +938,7 @@
       }
     },
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1080,7 +1080,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -1538,7 +1538,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-did.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-did.json
@@ -6,7 +6,131 @@
   },
   "forms": [
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Bill of Lading v2",
+      "type": "TRANSFERABLE_RECORD",
+      "defaults": {
+        "$template": {
+          "type": "EMBEDDED_RENDERER",
+          "name": "BILL_OF_LADING",
+          "url": "https://generic-templates.tradetrust.io"
+        },
+        "issuers": [
+          {
+            "identityProof": {
+              "type": "DNS-TXT",
+              "location": "demo-tradetrust.openattestation.com"
+            },
+            "name": "DEMO TOKEN REGISTRY"
+          }
+        ]
+      },
+      "schema": {
+        "type": "object",
+        "required": [
+          "blNumber",
+          "scac"
+        ],
+        "properties": {
+          "blNumber": {
+            "type": "string",
+            "title": "BL Number"
+          },
+          "scac": {
+            "type": "string",
+            "title": "Standard Carrier Alpha Code (SCAC)"
+          },
+          "carrierName": {
+            "title": "Signed for the Carrier",
+            "type": "string"
+          },
+          "shipper": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "address": {
+                "type": "object",
+                "properties": {
+                  "street": {
+                    "type": "string"
+                  },
+                  "country": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "consignee": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "notifyParty": {
+            "title": "Notify Party",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "vessel": {
+            "type": "string"
+          },
+          "voyageNo": {
+            "title": "Voyage No.",
+            "type": "string"
+          },
+          "portOfLoading": {
+            "title": "Port of Loading",
+            "type": "string"
+          },
+          "portOfDischarge": {
+            "title": "Port of Discharge",
+            "type": "string"
+          },
+          "placeOfReceipt": {
+            "title": "Place of Receipt",
+            "type": "string"
+          },
+          "placeOfDelivery": {
+            "title": "Place of Delivery",
+            "type": "string"
+          },
+          "packages": {
+            "type": "array",
+            "title": "Packages",
+            "items": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "measurement": {
+                  "type": "string"
+                },
+                "weight": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "attachments": {
+        "allow": true,
+        "accept": ".pdf, .json"
+      },
+      "extension": "tt",
+      "fileName": "bill-<%= blNumber %>"
+    },
+    {
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -437,7 +561,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -525,7 +649,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-did.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-did.json
@@ -130,7 +130,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-rinkeby.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-rinkeby.json
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-rinkeby.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-rinkeby.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -558,7 +558,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -642,7 +642,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten-aws.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten-aws.json
@@ -133,7 +133,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten-aws.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten-aws.json
@@ -8,7 +8,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -133,7 +133,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -560,7 +560,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -644,7 +644,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten.json
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v2",
+      "name": "TradeTrust ChAFTA Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/v2/sample-config-ropsten.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v2",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "$template": {
@@ -131,7 +131,7 @@
       "fileName": "bill-<%= blNumber %>"
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -558,7 +558,7 @@
       "extension": "tt"
     },
     {
-      "name": "Covering Letter",
+      "name": "TradeTrust Covering Letter v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {
@@ -642,7 +642,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v2",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "$template": {

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-did.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-did.json
@@ -6,7 +6,148 @@
   },
   "forms": [
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Bill of Lading v3",
+      "type": "TRANSFERABLE_RECORD",
+      "defaults": {
+        "version": "https://schema.openattestation.com/3.0/schema.json",
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
+          "https://schemata.openattestation.com/io/tradetrust/bill-of-lading/1.0/bill-of-lading-context.json"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "OpenAttestationCredential"
+        ],
+        "issuanceDate": "2010-01-01T19:23:24Z",
+        "openAttestationMetadata": {
+          "template": {
+            "type": "EMBEDDED_RENDERER",
+            "name": "BILL_OF_LADING",
+            "url": "https://generic-templates.tradetrust.io"
+          },
+          "proof": {
+            "type": "OpenAttestationProofMethod",
+            "method": "TOKEN_REGISTRY"
+          },
+          "identityProof": {
+            "type": "DNS-TXT",
+            "identifier": "demo-tradetrust.openattestation.com"
+          }
+        },
+        "credentialSubject": {},
+        "issuer": {
+          "id": "https://example.com",
+          "name": "DEMO TOKEN REGISTRY",
+          "type": "OpenAttestationIssuer"
+        }
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "credentialSubject": {
+            "type": "object",
+            "required": [
+              "blNumber",
+              "scac"
+            ],
+            "properties": {
+              "blNumber": {
+                "type": "string",
+                "title": "BL Number"
+              },
+              "scac": {
+                "type": "string",
+                "title": "Standard Carrier Alpha Code (SCAC)"
+              },
+              "carrierName": {
+                "title": "Signed for the Carrier",
+                "type": "string"
+              },
+              "shipper": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "address": {
+                    "type": "object",
+                    "properties": {
+                      "street": {
+                        "type": "string"
+                      },
+                      "country": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "consignee": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              },
+              "notifyParty": {
+                "title": "Notify Party",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              },
+              "vessel": {
+                "type": "string"
+              },
+              "voyageNo": {
+                "title": "Voyage No.",
+                "type": "string"
+              },
+              "portOfLoading": {
+                "title": "Port of Loading",
+                "type": "string"
+              },
+              "portOfDischarge": {
+                "title": "Port of Discharge",
+                "type": "string"
+              },
+              "placeOfReceipt": {
+                "title": "Place of Receipt",
+                "type": "string"
+              },
+              "placeOfDelivery": {
+                "title": "Place of Delivery",
+                "type": "string"
+              },
+              "packages": {
+                "type": "array",
+                "title": "Packages",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "measurement": {
+                      "type": "string"
+                    },
+                    "weight": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -467,7 +608,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-did.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-did.json
@@ -147,7 +147,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-rinkeby.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-rinkeby.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -148,7 +148,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -606,7 +606,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-rinkeby.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-rinkeby.json
@@ -148,7 +148,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-ropsten.json
@@ -6,7 +6,7 @@
   },
   "forms": [
     {
-      "name": "Bill of Lading",
+      "name": "TradeTrust Bill of Lading v3",
       "type": "TRANSFERABLE_RECORD",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -148,7 +148,7 @@
       }
     },
     {
-      "name": "COO (ChAFTA)",
+      "name": "TradeTrust Chafa Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",
@@ -606,7 +606,7 @@
       "extension": "tt"
     },
     {
-      "name": "Invoice",
+      "name": "TradeTrust Invoice v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/_generated-config-files/v3/sample-config-ropsten.json
+++ b/src/test/fixtures/config/_generated-config-files/v3/sample-config-ropsten.json
@@ -148,7 +148,7 @@
       }
     },
     {
-      "name": "TradeTrust Chafa Certificate of Origin v3",
+      "name": "TradeTrust ChAFTA Certificate of Origin v3",
       "type": "VERIFIABLE_DOCUMENT",
       "defaults": {
         "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/forms/v2/bill-of-lading.json
+++ b/src/test/fixtures/config/forms/v2/bill-of-lading.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bill of Lading",
+  "name": "TradeTrust Bill of Lading v2",
   "type": "TRANSFERABLE_RECORD",
   "defaults": {
     "$template": {

--- a/src/test/fixtures/config/forms/v2/coo-chafta.json
+++ b/src/test/fixtures/config/forms/v2/coo-chafta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TradeTrust Chafa Certificate of Origin v2",
+  "name": "TradeTrust ChAFTA Certificate of Origin v2",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "$template": {

--- a/src/test/fixtures/config/forms/v2/coo-chafta.json
+++ b/src/test/fixtures/config/forms/v2/coo-chafta.json
@@ -1,5 +1,5 @@
 {
-  "name": "COO (ChAFTA)",
+  "name": "TradeTrust Chafa Certificate of Origin v2",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "$template": {

--- a/src/test/fixtures/config/forms/v2/cover-letter.json
+++ b/src/test/fixtures/config/forms/v2/cover-letter.json
@@ -1,5 +1,5 @@
 {
-  "name": "Covering Letter",
+  "name": "TradeTrust Covering Letter v2",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "$template": {

--- a/src/test/fixtures/config/forms/v2/invoice.json
+++ b/src/test/fixtures/config/forms/v2/invoice.json
@@ -1,5 +1,5 @@
 {
-  "name": "Invoice",
+  "name": "TradeTrust Invoice v2",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "$template": {

--- a/src/test/fixtures/config/forms/v3/bill-of-lading.json
+++ b/src/test/fixtures/config/forms/v3/bill-of-lading.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bill of Lading",
+  "name": "TradeTrust Bill of Lading v3",
   "type": "TRANSFERABLE_RECORD",
   "defaults": {
     "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/forms/v3/coo-chafta.json
+++ b/src/test/fixtures/config/forms/v3/coo-chafta.json
@@ -1,5 +1,5 @@
 {
-  "name": "TradeTrust Chafa Certificate of Origin v3",
+  "name": "TradeTrust ChAFTA Certificate of Origin v3",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/forms/v3/coo-chafta.json
+++ b/src/test/fixtures/config/forms/v3/coo-chafta.json
@@ -1,5 +1,5 @@
 {
-  "name": "COO (ChAFTA)",
+  "name": "TradeTrust Chafa Certificate of Origin v3",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "version": "https://schema.openattestation.com/3.0/schema.json",

--- a/src/test/fixtures/config/forms/v3/invoice.json
+++ b/src/test/fixtures/config/forms/v3/invoice.json
@@ -1,5 +1,5 @@
 {
-  "name": "Invoice",
+  "name": "TradeTrust Invoice v3",
   "type": "VERIFIABLE_DOCUMENT",
   "defaults": {
     "version": "https://schema.openattestation.com/3.0/schema.json",


### PR DESCRIPTION
## Summary
Rename the forms to be able to identify v2 and v3 forms when both are in a configuration file

## Changes

- Forms name
- Test cases selector and file download validator

