### PR TITLE
feat: skip dependabot build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,6 @@
   from = "/*"
   to = "/"
   status = 200
+
+[build]
+  ignore = "git log -1 --pretty=%B | grep dependabot"


### PR DESCRIPTION
- to start reviewing / accepting dependabot prs
- see if can skip / not waste unnecessary netlify build times for dependabot prs when they auto rebase
- https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times