### PR TITLE
Feat/add network in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ## Integration test flow (locally)
 
+- Firstly, you have to run build, as the integration run script will serve static.
+
 - run 2 instances concurrently, 1 = `npm run blockchain`, 1 = `npm run integration`
+
+- to test a specific file, you will need run 2 instances concurrently, 1 = `npm run blockchain`, 1 = `npm run integration:single integration/<file name>.spec.ts`
 
 ## Windows Gotchas
 
 [cross-env](https://www.npmjs.com/package/cross-env) is required to run the npm scripts. It should be installed when running `npm install`
 
-Encountered _File name differs from already included file name only in casing_ error? Ensure that the absolute paths specified in the error are *exactly* the same and that the casings match. 
+Encountered _File name differs from already included file name only in casing_ error? Ensure that the absolute paths specified in the error are _exactly_ the same and that the casings match.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4499,6 +4499,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -4701,9 +4706,9 @@
       }
     },
     "@govtechsg/open-attestation": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-6.2.0.tgz",
-      "integrity": "sha512-LSssNwtEXHvkJFKlP/rOCdx1S8S1B2k5MwgDvtUVbhLiBKDlmSbUZl3FS5uCF7bTHzaJJmgDrxZs5QJ969gE3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-6.3.0.tgz",
+      "integrity": "sha512-XII0VbOxL03OlYeepoU8Rn4/PZ/dhUxGaVgzZBujo+mORsnaGLjky8CxiyB5PNi0csoL+kaZoOKJxNpDMPRfAQ==",
       "requires": {
         "@govtechsg/jsonld": "^0.1.0",
         "ajv": "^8.6.2",
@@ -4721,9 +4726,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -38542,11 +38547,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
-    },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,12 +360,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -4498,11 +4492,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "penpal-v4": {
-          "version": "npm:penpal@4.1.1",
-          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
         },
         "readable-stream": {
           "version": "3.6.0",
@@ -9404,12 +9393,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -11121,12 +11104,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.75"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
         },
         "colorette": {
           "version": "1.3.0",
@@ -12900,12 +12877,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14304,12 +14275,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -14830,12 +14795,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.75"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
         },
         "chalk": {
           "version": "4.1.2",
@@ -20049,12 +20008,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -21789,9 +21742,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001233",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz",
-      "integrity": "sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg=="
+      "version": "1.0.30001310",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz",
+      "integrity": "sha512-cb9xTV8k9HTIUA3GnPUJCk0meUnrHL5gy5QePfDjxHyNBcnzPzrHFv5GqfP7ue5b1ZyzZL0RJboD6hQlPXjhjg=="
     },
     "canonicalize": {
       "version": "1.0.5",
@@ -38547,6 +38500,11 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
+    },
+    "penpal-v4": {
+      "version": "npm:penpal@4.1.1",
+      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@govtechsg/document-store": "^2.2.1",
     "@govtechsg/ethers-contract-hook": "^2.2.0",
     "@govtechsg/oa-verify": "^7.7.0",
-    "@govtechsg/open-attestation": "^6.2.0",
+    "@govtechsg/open-attestation": "^6.3.0",
     "@govtechsg/token-registry": "^2.5.2",
     "@govtechsg/tradetrust-ui-components": "^2.12.1",
     "@govtechsg/tradetrust-utils": "^1.0.1",

--- a/src/common/context/forms/index.tsx
+++ b/src/common/context/forms/index.tsx
@@ -94,7 +94,9 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
       if (e instanceof ReferenceError) {
         throw new Error("failed to interpolate data properties, could not find data properties in configuration file.");
       }
-      throw new Error(e);
+      if (e instanceof Error) {
+        throw new Error(e.message);
+      }
     }
   };
 
@@ -133,7 +135,9 @@ export const FormsContextProvider: FunctionComponent = ({ children }) => {
       if (e instanceof ReferenceError) {
         throw new Error("failed to interpolate data properties, could not find data properties in configuration file.");
       }
-      throw new Error(e);
+      if (e instanceof Error) {
+        throw new Error(e.message);
+      }
     }
   };
 

--- a/src/common/hook/useQueue/utils/publish.tsx
+++ b/src/common/hook/useQueue/utils/publish.tsx
@@ -7,7 +7,7 @@ import { defaultsDeep, groupBy } from "lodash";
 import { IdentityProofType } from "../../../../constants";
 import { ActionsUrlObject, Config, DocumentStorage, FormEntry, PublishingJob, RawDocument } from "../../../../types";
 import { getQueueNumber } from "../../../API/storageAPI";
-import { encodeQrCode } from "../../../utils";
+import { encodeQrCode, getDocumentNetwork } from "../../../utils";
 import { Signer } from "ethers";
 import { publishDnsDidVerifiableDocumentJob } from "../../../../services/publishing";
 
@@ -75,11 +75,15 @@ export const getRawDocuments = async (forms: FormEntry[], config: Config): Promi
       const formConfig = config.forms[templateIndex];
       if (!formConfig) throw new Error("Form definition not found");
       const formDefaults = formConfig.defaults;
+      const documentNetwork = getDocumentNetwork(config.network);
       let formData;
       if (utils.isRawV3Document(data.formData)) {
-        formData = { ...data.formData, credentialSubject: { ...data.formData.credentialSubject, ...qrUrl } };
+        formData = {
+          ...data.formData,
+          credentialSubject: { ...data.formData.credentialSubject, ...qrUrl, ...documentNetwork },
+        };
       } else {
-        formData = { ...data.formData, ...qrUrl };
+        formData = { ...data.formData, ...qrUrl, ...documentNetwork };
       }
       defaultsDeep(formData, formDefaults);
       const contractAddress = getContractAddressFromRawDoc(formData);

--- a/src/common/hook/useQueue/utils/publish.tsx
+++ b/src/common/hook/useQueue/utils/publish.tsx
@@ -80,7 +80,8 @@ export const getRawDocuments = async (forms: FormEntry[], config: Config): Promi
       if (utils.isRawV3Document(data.formData)) {
         formData = {
           ...data.formData,
-          credentialSubject: { ...data.formData.credentialSubject, ...qrUrl, ...documentNetwork },
+          ...documentNetwork,
+          credentialSubject: { ...data.formData.credentialSubject, ...qrUrl },
         };
       } else {
         formData = { ...data.formData, ...qrUrl, ...documentNetwork };
@@ -220,5 +221,6 @@ export const getPublishingJobs = async (
 ): Promise<PublishingJob[]> => {
   // Currently works for only multiple verifiable document issuance:
   const rawDocuments = await getRawDocuments(forms, config);
+  console.log("raw", rawDocuments);
   return groupDocumentsIntoJobs(rawDocuments, nonce, signer);
 };

--- a/src/common/hook/useQueue/utils/sample-formatted-with-dns-did.json
+++ b/src/common/hook/useQueue/utils/sample-formatted-with-dns-did.json
@@ -24,6 +24,10 @@
         }
       ],
       "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -55,6 +59,10 @@
         }
       ],
       "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -91,6 +99,10 @@
         }
       ],
       "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -122,6 +134,10 @@
         }
       ],
       "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"

--- a/src/common/hook/useQueue/utils/sample-formatted-without-qr-url.json
+++ b/src/common/hook/useQueue/utils/sample-formatted-without-qr-url.json
@@ -19,7 +19,11 @@
           }
         }
       ],
-      "name": "CHAFTA Certificate of Origin"
+      "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      }
     },
     "fileName": "Document-1.tt",
     "extension": "tt",
@@ -45,7 +49,11 @@
           "tokenRegistry": "0x10E936e6BA85dC92505760259881167141365821"
         }
       ],
-      "name": "Maersk Bill of Lading"
+      "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      }
     },
     "fileName": "Document-2.tt",
     "extension": "tt",
@@ -76,7 +84,11 @@
           }
         }
       ],
-      "name": "CHAFTA Certificate of Origin"
+      "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      }
     },
     "fileName": "Document-3.tt",
     "extension": "tt",
@@ -102,7 +114,11 @@
           "tokenRegistry": "0x10E936e6BA85dC92505760259881167141365821"
         }
       ],
-      "name": "Maersk Bill of Lading"
+      "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      }
     },
     "fileName": "Document-4.tt",
     "extension": "tt",

--- a/src/common/hook/useQueue/utils/sample-formatted.json
+++ b/src/common/hook/useQueue/utils/sample-formatted.json
@@ -20,6 +20,10 @@
         }
       ],
       "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -51,6 +55,10 @@
         }
       ],
       "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -87,6 +95,10 @@
         }
       ],
       "name": "CHAFTA Certificate of Origin",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
@@ -118,6 +130,10 @@
         }
       ],
       "name": "Maersk Bill of Lading",
+      "network": {
+        "chain": "ETH",
+        "chainId": "3"
+      },
       "links": {
         "self": {
           "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"

--- a/src/common/utils.test.tsx
+++ b/src/common/utils.test.tsx
@@ -1,4 +1,4 @@
-import { decodeQrCode, encodeQrCode } from "./utils";
+import { decodeQrCode, encodeQrCode, getDocumentNetwork } from "./utils";
 
 describe("encodeQrCode", () => {
   it("should encode the url into the correct format", () => {
@@ -36,5 +36,16 @@ describe("decodeQrCode", () => {
   it("throws when qr code is malformed", () => {
     const encodedQrCode = "http://%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
     expect(() => decodeQrCode(encodedQrCode)).toThrow("not formatted");
+  });
+});
+
+describe("getDocumentNetwork", () => {
+  it("should get the network details based on the network given", () => {
+    expect(getDocumentNetwork("ropsten")).toStrictEqual({ network: { chain: "ETH", chainId: "3" } });
+  });
+
+  it("should throw an error when the network is not in the list", () => {
+    // @ts-expect-error: Test if the error will throw when its not one of the type in the Network enum.
+    expect(() => getDocumentNetwork("abc")).toThrow("Unsupported network abc");
   });
 });

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -1,7 +1,8 @@
 import { csv2jsonAsync } from "json-2-csv";
 import converter from "json-2-csv";
 import { saveAs } from "file-saver";
-import { WalletOptions } from "../types";
+import { WalletOptions, Network, NetworkObject } from "../types";
+import { ChainId, ChainInfo } from "../constants/chainInfo";
 
 export function readFileAsJson<T>(file: File): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -83,4 +84,19 @@ export const downloadJsonDataFile = (jsonTemplate: any): void => {
 
 export const isWalletOption = (option: string | WalletOptions): option is string => {
   return typeof option === "string";
+};
+
+export const getDocumentNetwork = (network: Network): NetworkObject => {
+  const chainInfo = Object.keys(ChainInfo)
+    .map((chainId) => ChainInfo[Number(chainId) as ChainId])
+    .find((info) => info.networkName === network);
+
+  if (!chainInfo) throw new Error(`Unsupported network ${network}`);
+
+  return {
+    network: {
+      chain: chainInfo?.chain,
+      chainId: chainInfo?.chainId.toString(),
+    },
+  };
 };

--- a/src/constants/chainInfo.tsx
+++ b/src/constants/chainInfo.tsx
@@ -1,0 +1,86 @@
+export interface ChainInfoObject {
+  label: string;
+  chain: string;
+  chainId: ChainId;
+  networkName: string; // network name that aligns with existing NETWORK_NAME
+  explorerUrl: string;
+}
+
+type ChainInfo = Record<ChainId, ChainInfoObject>;
+
+export enum ChainId {
+  // Localhost
+  Local = 1337,
+
+  // Ethereum Mainnet
+  Ethereum = 1,
+
+  // Ethereum Testnet
+  Ropsten = 3,
+  Rinkeby = 4,
+  Goerli = 5,
+  Kovan = 42,
+
+  // Polygon
+  Polygon = 137,
+  PolygonMumbai = 80001,
+}
+
+export const ChainInfo: ChainInfo = {
+  [ChainId.Local]: {
+    label: "Local",
+    chain: "ETH",
+    chainId: ChainId.Local,
+    networkName: "local",
+    explorerUrl: "https://localhost/explorer",
+  },
+  [ChainId.Ethereum]: {
+    label: "Ethereum",
+    chain: "ETH",
+    chainId: ChainId.Ethereum,
+    networkName: "homestead",
+    explorerUrl: "https://etherscan.io",
+  },
+  [ChainId.Ropsten]: {
+    label: "Ropsten",
+    chain: "ETH",
+    chainId: ChainId.Ropsten,
+    networkName: "ropsten",
+    explorerUrl: "https://ropsten.etherscan.io",
+  },
+  [ChainId.Rinkeby]: {
+    label: "Rinkeby",
+    chain: "ETH",
+    chainId: ChainId.Rinkeby,
+    networkName: "rinkeby",
+    explorerUrl: "https://rinkeby.etherscan.io",
+  },
+  [ChainId.Goerli]: {
+    label: "Goerli",
+    chain: "ETH",
+    chainId: ChainId.Goerli,
+    networkName: "goerli",
+    explorerUrl: "https://goerli.etherscan.io",
+  },
+  [ChainId.Kovan]: {
+    label: "Kovan",
+    chain: "ETH",
+    chainId: ChainId.Kovan,
+    networkName: "kovan",
+    explorerUrl: "https://kovan.etherscan.io",
+  },
+  [ChainId.Polygon]: {
+    label: "Polygon (Beta)",
+    chain: "MATIC",
+    chainId: ChainId.Polygon,
+    networkName: "matic",
+    explorerUrl: "https://polygonscan.com",
+  },
+  [ChainId.PolygonMumbai]: {
+    label: "Polygon Mumbai",
+    chain: "MATIC",
+    chainId: ChainId.PolygonMumbai,
+    networkName: "maticmum",
+    explorerUrl: "https://mumbai.polygonscan.com",
+  },
+};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,8 @@
 import { Wallet, Signer } from "ethers";
 import { Provider } from "@ethersproject/abstract-provider";
+import { OpenAttestationDocument } from "@govtechsg/open-attestation";
 
-type Network = "homestead" | "ropsten" | "rinkeby" | "local";
+export type Network = "homestead" | "ropsten" | "rinkeby" | "local";
 type FormType = "TRANSFERABLE_RECORD" | "VERIFIABLE_DOCUMENT";
 
 // FormTemplate is defined in configuration file
@@ -103,7 +104,7 @@ export interface SetFormParams {
 export interface RawDocument {
   type: FormType;
   contractAddress: string;
-  rawDocument: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  rawDocument: OpenAttestationDocument;
   fileName: string;
   payload: { ownership?: Ownership };
   extension: string;
@@ -140,4 +141,11 @@ export interface ActionsUrlObject {
 export interface QueueNumberResponse {
   id: string;
   key: string;
+}
+
+export interface NetworkObject {
+  network: {
+    chain: string;
+    chainId: string;
+  };
 }


### PR DESCRIPTION
## Summary

To add auto-network switching feature into creator, so that the document issued by creator can use the auto-network switching feature in TT.io sites.

 Document issued with the new network object inside can still be verified with the old/existing verifier in TT.io/dev.TT.io/ropsten.TT.io as long as you are in the correct network. 

## Changes

- Add function to generate the network based on the network in the config file.
- Update test cases

## Issues

https://www.pivotaltracker.com/n/projects/2424361/stories/181043341
