### PR TITLE
fix: ajv error message

### DIFF
--- a/integration/document-data-upload-error.spec.ts
+++ b/integration/document-data-upload-error.spec.ts
@@ -9,8 +9,8 @@ const FormSelectionTitle = Selector("[data-testid='form-selection-title']");
 const ProgressBar = Selector("[data-testid='progress-bar']");
 
 const Button = Selector("button");
-const ErrorItem1 = Selector("[data-testid='form-error-banner'] li").nth(0);
-const ErrorItem2 = Selector("[data-testid='form-error-banner'] li").nth(1);
+const ErrorItem1 = Selector("[data-testid='form-error-banner'] li h6").nth(0);
+const ErrorItem2 = Selector("[data-testid='form-error-banner'] li h6").nth(1);
 const DataFileDropZoneInput = Selector("[data-testid='data-file-dropzone'] input");
 
 test("should show validation error messages correctly", async (t) => {
@@ -32,6 +32,6 @@ test("should show validation error messages correctly", async (t) => {
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileJsonEblMissingFields]);
 
   // Assert validation error messages
-  await t.expect(ErrorItem1.textContent).contains("must have required property 'blNumber'");
-  await t.expect(ErrorItem2.textContent).contains("must have required property 'scac'");
+  await t.expect(ErrorItem1.textContent).contains("missingProperty: blNumber");
+  await t.expect(ErrorItem2.textContent).contains("missingProperty: scac");
 });

--- a/integration/document-data-upload.spec.ts
+++ b/integration/document-data-upload.spec.ts
@@ -147,7 +147,7 @@ test("should show error on v2 document when data file with additional properties
   await t.click(Button.withText("TradeTrust Invoice v2"));
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCoo]);
 
-  await t.expect(Selector("li").withText(/must NOT have additional properties/i).exists).ok();
+  await t.expect(Selector("li h6").textContent).contains("additionalProperty: iD");
 });
 
 test("should show error on v3 document when data file with additional properties is used", async (t) => {
@@ -157,5 +157,5 @@ test("should show error on v3 document when data file with additional properties
   await t.click(Button.withText("TradeTrust Invoice v3"));
   await t.setFilesToUpload(DataFileDropZoneInput, [dataFileCsvCoo]);
 
-  await t.expect(Selector("li").withText(/must NOT have additional properties/i).exists).ok();
+  await t.expect(Selector("li h6").textContent).contains("additionalProperty: iD");
 });

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -2,8 +2,8 @@ import { csv2jsonAsync } from "json-2-csv";
 import converter from "json-2-csv";
 import { saveAs } from "file-saver";
 import { JSONSchema } from "json-schema-library";
-import Ajv, { ErrorObject } from "ajv";
-import { WalletOptions, Network, NetworkObject } from "../types";
+import Ajv from "ajv";
+import { WalletOptions, Network, NetworkObject, FormErrors } from "../types";
 import { ChainId, ChainInfo, ChainInfoObject } from "../constants/chainInfo";
 
 export function readFileAsJson<T>(file: File): Promise<T> {
@@ -128,10 +128,7 @@ export const getDataToValidate: any = (data: any) => {
   }
 };
 
-export const validateData = (
-  schema: JSONSchema,
-  data: unknown
-): { isValid: boolean; ajvErrors: ErrorObject[] | null | undefined } => {
+export const validateData = (schema: JSONSchema, data: unknown): { isValid: boolean; ajvErrors: FormErrors } => {
   const ajv = new Ajv({ allErrors: true });
   const isValid = ajv.validate(schema, data);
 

--- a/src/components/DynamicFormContainer/DataFileButton/DataFileButton.test.tsx
+++ b/src/components/DynamicFormContainer/DataFileButton/DataFileButton.test.tsx
@@ -63,7 +63,7 @@ describe("dataFileButton", () => {
 
     await act(async () => {
       fireEvent(dropzone, event);
-      await waitFor(() => expect(screen.getByTestId("file-read-error")).not.toBeUndefined());
+      await waitFor(() => expect(screen.getByTestId("file-error")).not.toBeUndefined());
     });
   });
 
@@ -99,7 +99,7 @@ describe("dataFileButton", () => {
 
     await act(async () => {
       fireEvent(dropzone, event);
-      await waitFor(() => expect(screen.getByTestId("file-read-error")).not.toBeUndefined());
+      await waitFor(() => expect(screen.getByTestId("file-schema-error")).not.toBeUndefined());
     });
   });
 

--- a/src/components/DynamicFormContainer/DataFileButton/DataFileButton.tsx
+++ b/src/components/DynamicFormContainer/DataFileButton/DataFileButton.tsx
@@ -65,7 +65,6 @@ export const DataFileButton: FunctionComponent<DataFileButton> = ({ onDataFile, 
   const [formErrors, setFormErrors] = useState<FormErrors>();
 
   const onDropAccepted = async (files: File[]): Promise<void> => {
-    console.log(files[0], "???");
     try {
       const file = files[0];
       const { dataFile, dataToValidate } = await getDataFileBasedOnExtension(file);

--- a/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
+++ b/src/components/DynamicFormContainer/DynamicForm/AttachmentDropzone/AttachmentDropzone.tsx
@@ -18,7 +18,7 @@ export const AttachmentDropzone: FunctionComponent<AttachmentDropzone> = ({
   onRemove,
   uploadedFiles,
 }) => {
-  const [fileErrors, setFileErrors] = useState<Error[]>();
+  const [fileErrors, setFileErrors] = useState<Error[]>([]);
 
   const onDropAccepted = useCallback(
     async (files: File[]) => {
@@ -36,7 +36,7 @@ export const AttachmentDropzone: FunctionComponent<AttachmentDropzone> = ({
         );
         return setFileErrors([totalFileSizeError]);
       } else {
-        setFileErrors(undefined);
+        setFileErrors([]);
       }
 
       const processedFiles = await Promise.all(files.map(processFiles));

--- a/src/components/DynamicFormContainer/DynamicFormLayout.tsx
+++ b/src/components/DynamicFormContainer/DynamicFormLayout.tsx
@@ -1,5 +1,4 @@
 import { LoaderSpinner, ToggleSwitch } from "@govtechsg/tradetrust-ui-components";
-import { ErrorObject } from "ajv";
 import { defaultsDeep } from "lodash";
 import React, { FunctionComponent, useState } from "react";
 import { Trash2 } from "react-feather";
@@ -17,6 +16,7 @@ import { DynamicForm } from "./DynamicForm";
 import { DynamicFormHeader } from "./DynamicFormHeader";
 import { FormErrorBanner } from "./FormErrorBanner";
 import { validateData, getDataToValidate } from "./../../common/utils";
+import { FormErrors } from "./../../types";
 
 export const DynamicFormLayout: FunctionComponent = () => {
   const [showDeleteModal, setDeleteModal] = useState(false);
@@ -39,7 +39,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
   } = useFormsContext();
   const { config } = useConfigContext();
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const [formError, setFormError] = useState<ErrorObject[] | null | undefined>(null);
+  const [formErrors, setFormErrors] = useState<FormErrors>(null);
 
   // if (!config) return <Redirect to="/" />;
   if (!currentForm) return <Redirect to="/forms-selection" />;
@@ -53,7 +53,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
   const validateCurrentForm = (): boolean => {
     const dataToValidate = getDataToValidate(currentForm.data.formData);
     const { isValid, ajvErrors } = validateData(currentForm.data.schema, dataToValidate);
-    setFormError(ajvErrors);
+    setFormErrors(ajvErrors);
     return isValid;
   };
 
@@ -89,7 +89,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
   const deleteForm = (): void => {
     removeCurrentForm();
     closeDeleteModal();
-    setFormError(null);
+    setFormErrors(null);
   };
 
   const closeBackModal = (): void => {
@@ -156,7 +156,7 @@ export const DynamicFormLayout: FunctionComponent = () => {
               <>
                 <FormErrorBanner
                   formErrorTitle="This form has errors. Please fix the errors to proceed."
-                  formError={formError}
+                  formErrors={formErrors}
                 />
                 {isPreviewMode ? (
                   <div className="max-w-screen-xl mx-auto mt-6">

--- a/src/components/DynamicFormContainer/FormErrorBanner/FormErrorBanner.test.tsx
+++ b/src/components/DynamicFormContainer/FormErrorBanner/FormErrorBanner.test.tsx
@@ -14,17 +14,17 @@ const errors = [
 
 describe("formErrorBanner", () => {
   it("should show errors when there are any", () => {
-    render(<FormErrorBanner formErrorTitle="" formError={errors} />);
-    expect(screen.getByTestId("form-error-banner")).toHaveTextContent("should have required property 'blNumber'");
+    render(<FormErrorBanner formErrorTitle="" formErrors={errors} />);
+    expect(screen.getByTestId("form-error-banner")).toHaveTextContent("missingProperty: blNumber");
   });
 
   it("should not display when there are no errors", () => {
-    render(<FormErrorBanner formErrorTitle="" formError={undefined} />);
+    render(<FormErrorBanner formErrorTitle="" formErrors={null} />);
     expect(screen.queryByTestId("form-error-banner")).toBeNull();
   });
 
   it("should display formErrorTitle correctly", () => {
-    render(<FormErrorBanner formErrorTitle="Some error occurred" formError={errors} />);
+    render(<FormErrorBanner formErrorTitle="Some error occurred" formErrors={errors} />);
     expect(screen.getByText("Some error occurred")).not.toBeNull();
   });
 });

--- a/src/components/DynamicFormContainer/FormErrorBanner/FormErrorBanner.tsx
+++ b/src/components/DynamicFormContainer/FormErrorBanner/FormErrorBanner.tsx
@@ -1,31 +1,34 @@
-import { ErrorObject } from "ajv";
 import React, { FunctionComponent } from "react";
 import { XCircle } from "react-feather";
-
-export type FormError = ErrorObject[] | null | undefined;
+import { AjvErrorMessage } from "./../../UI/AjvError";
+import { FormErrors } from "../../../types";
 
 interface FormErrorBanner {
-  formErrorTitle: string | null | undefined;
-  formError: FormError;
+  formErrorTitle: string | null;
+  formErrors: FormErrors;
 }
-export const FormErrorBanner: FunctionComponent<FormErrorBanner> = ({ formErrorTitle, formError }) => {
-  if (!formError || !(formError.length > 0)) return null;
+
+/**
+ * FormErrorBanner
+ * Shows a list of ajv errors for end user to self-diagnose and error recovery
+ * @param formErrorTitle Custom error message title
+ * @param formError Array of errors generated from ajv validation
+ */
+export const FormErrorBanner: FunctionComponent<FormErrorBanner> = ({ formErrorTitle, formErrors }) => {
+  if (!formErrors || !(formErrors.length > 0)) return null;
 
   return (
     <div data-testid="form-error-banner" className="bg-red-100 rounded-lg mx-auto flex items-center p-6 mt-4">
       <XCircle className="text-scarlet-500 mx-3 my-1 h-10 w-10" />
-      <div className="text-scarlet-500 font-gilroy-bold flex flex-col justify-center items-left ml-4">
-        <div>{formErrorTitle}</div>
-        <ul className="list-disc pl-5">
-          {formError &&
-            formError.map((error, index: number) => {
-              return (
-                <li key={index}>
-                  {error.instancePath} {error.message}
-                </li>
-              );
+      <div className="font-gilroy-bold flex flex-col justify-center items-left ml-4">
+        <p className="text-scarlet-500 text-lg leading-none font-gilroy-bold mb-2">{formErrorTitle}</p>
+        {formErrors && (
+          <div className="text-scarlet-500">
+            {formErrors.map((error, index: number) => {
+              return <AjvErrorMessage key={index} error={error} />;
             })}
-        </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.tsx
+++ b/src/components/Home/ConfigFileDropZone/ConfigFileDropZone.tsx
@@ -13,14 +13,14 @@ interface ConfigFileDropZone {
 }
 
 export const ConfigFileDropZone: FunctionComponent<ConfigFileDropZone> = ({ onConfigFile, errorMessage }) => {
-  const [fileErrors, setFileErrors] = useState<Error[]>();
+  const [fileErrors, setFileErrors] = useState<Error[]>([]);
 
   useEffect(() => {
     if (errorMessage) {
       const malformedError = new Error(errorMessage);
       setFileErrors([malformedError]);
     } else {
-      setFileErrors(undefined);
+      setFileErrors([]);
     }
   }, [errorMessage]);
 
@@ -28,7 +28,7 @@ export const ConfigFileDropZone: FunctionComponent<ConfigFileDropZone> = ({ onCo
     try {
       const file = files[0];
       const config = await readFileAsJson<ConfigFile>(file);
-      setFileErrors(undefined);
+      setFileErrors([]);
       onConfigFile(config);
     } catch (e) {
       if (e instanceof Error) {

--- a/src/components/RevokeContainer/RevokeDocumentDropZone/RevokeDocumentDropZone.tsx
+++ b/src/components/RevokeContainer/RevokeDocumentDropZone/RevokeDocumentDropZone.tsx
@@ -29,7 +29,7 @@ export const RevokeDocumentDropZone: FunctionComponent<RevokeDocumentDropZone> =
   documentUploadState,
   setDocumentUploadState,
 }) => {
-  const [fileErrors, setFileErrors] = useState<Error[]>();
+  const [fileErrors, setFileErrors] = useState<Error[]>([]);
 
   useEffect(() => {
     if (documentUploadState === DocumentUploadState.ERROR) {
@@ -39,7 +39,7 @@ export const RevokeDocumentDropZone: FunctionComponent<RevokeDocumentDropZone> =
           : [new Error("Document cannot be read. Please check that you have a valid document")];
       setFileErrors(readFileError);
     } else {
-      setFileErrors(undefined);
+      setFileErrors([]);
     }
   }, [documentUploadState, errorMessages]);
 

--- a/src/components/UI/AjvError/AjvErrorMessage.stories.tsx
+++ b/src/components/UI/AjvError/AjvErrorMessage.stories.tsx
@@ -1,0 +1,24 @@
+import { FunctionComponent } from "react";
+import { AjvErrorMessage } from "./AjvErrorMessage";
+
+const mockError = {
+  instancePath: "",
+  schemaPath: "#/additionalProperties",
+  keyword: "additionalProperties",
+  params: {
+    additionalProperty: "supplyChainConsignment",
+  },
+  message: "must NOT have additional properties",
+};
+
+export default {
+  title: "UI/AjvErrorMessage",
+  component: AjvErrorMessage,
+  parameters: {
+    componentSubtitle: "AjvErrorMessage",
+  },
+};
+
+export const Default: FunctionComponent = () => {
+  return <AjvErrorMessage error={mockError} />;
+};

--- a/src/components/UI/AjvError/AjvErrorMessage.test.tsx
+++ b/src/components/UI/AjvError/AjvErrorMessage.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Default as AjvErrorMessage } from "./AjvErrorMessage.stories";
+
+describe("AjvErrorMessage", () => {
+  it("should show formatted correct error message", () => {
+    render(<AjvErrorMessage />);
+    expect(screen.getByTestId("ajv-error-msg").textContent).toBe("additionalProperty: supplyChainConsignment");
+  });
+});

--- a/src/components/UI/AjvError/AjvErrorMessage.tsx
+++ b/src/components/UI/AjvError/AjvErrorMessage.tsx
@@ -1,0 +1,20 @@
+import React, { FunctionComponent } from "react";
+import { ErrorObject } from "ajv";
+
+export const AjvErrorMessage: FunctionComponent<{ error: ErrorObject }> = (props) => {
+  const { params } = props.error;
+
+  return (
+    <ul className="list-disc pl-5 text-left">
+      {Object.keys(params).map((key, index) => {
+        return (
+          <li key={index}>
+            <h6 data-testid="ajv-error-msg">
+              <span className="font-semibold">{key}</span>: {params[key]}
+            </h6>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/src/components/UI/AjvError/index.tsx
+++ b/src/components/UI/AjvError/index.tsx
@@ -1,0 +1,1 @@
+export * from "./AjvErrorMessage";

--- a/src/components/UI/StyledDropZone/StyledDropZone.stories.tsx
+++ b/src/components/UI/StyledDropZone/StyledDropZone.stories.tsx
@@ -15,6 +15,7 @@ export const Default: FunctionComponent = () => (
     dropzoneOptions={{}}
     defaultStyle="bg-white"
     activeStyle="bg-cloud-200"
+    fileErrors={[]}
     dropzoneIcon="/upload-icon-dark.png"
   >
     <div className="font-gilroy-bold text-lg text-cloud-800">Drag and drop your file(s) here</div>
@@ -28,11 +29,12 @@ export const DifferentBackgroundColor: FunctionComponent = () => (
     dropzoneOptions={{}}
     defaultStyle="bg-yellow-50"
     activeStyle="bg-yellow-100"
+    fileErrors={[]}
     dropzoneIcon="/upload-icon-dark.png"
   >
     <div className="font-gilroy-bold text-lg text-cloud-800">Drag and drop your file(s) here</div>
     <div className="mt-4">or</div>
-    <button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</button>
+    <Button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</Button>
   </StyledDropZone>
 );
 
@@ -41,11 +43,12 @@ export const DifferentIcons: FunctionComponent = () => (
     dropzoneOptions={{}}
     defaultStyle="bg-white"
     activeStyle="bg-cloud-200"
+    fileErrors={[]}
     dropzoneIcon="/dropzone-graphic.png"
   >
     <div className="font-gilroy-bold text-lg text-cloud-800">Drag and drop your file(s) here</div>
     <div className="mt-4">or</div>
-    <button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</button>
+    <Button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</Button>
   </StyledDropZone>
 );
 
@@ -59,6 +62,6 @@ export const withErrors: FunctionComponent = () => (
   >
     <div className="font-gilroy-bold text-lg text-cloud-800">Drag and drop your file(s) here</div>
     <div className="mt-4">or</div>
-    <button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</button>
+    <Button className="bg-cerulean-500 text-white hover:bg-cerulean-800 mt-4">Browse File</Button>
   </StyledDropZone>
 );

--- a/src/components/UI/StyledDropZone/StyledDropZone.tsx
+++ b/src/components/UI/StyledDropZone/StyledDropZone.tsx
@@ -1,11 +1,8 @@
-import { ErrorObject } from "ajv";
 import { trim } from "lodash";
 import { FunctionComponent, useMemo, useState } from "react";
 import { DropzoneOptions, FileRejection, useDropzone } from "react-dropzone";
 import { FileUpload } from "../../../constants/FileUpload";
 import { ErrorMessage } from "./ErrorMessage";
-
-type DropZoneFileErrors = ErrorObject[] | Error[] | null | undefined;
 
 interface DropZoneProps {
   defaultStyle: string;
@@ -14,7 +11,7 @@ interface DropZoneProps {
   rejectStyle?: string;
   children: React.ReactNode;
   dropzoneOptions: DropzoneOptions;
-  fileErrors?: DropZoneFileErrors;
+  fileErrors: Error[];
   dropzoneIcon?: string;
   dataTestId?: string;
 }
@@ -66,7 +63,7 @@ export const StyledDropZone: FunctionComponent<DropZoneProps> = ({
 
   const { getInputProps, getRootProps, isDragActive, isDragAccept, isDragReject } = useDropzone(dropzoneOptions);
 
-  const error = fileTypeError || fileSizeError || tooManyFilesError || !!fileErrors;
+  const error = fileTypeError || fileSizeError || tooManyFilesError || fileErrors.length > 0;
   const currentStyle = error ? errorStyle : defaultStyle;
   const dragStyle = useMemo(() => {
     return trim(`
@@ -80,7 +77,6 @@ export const StyledDropZone: FunctionComponent<DropZoneProps> = ({
     <div className={`${baseStyle} ${dragStyle || currentStyle} `} data-testid={dataTestId} {...getRootProps()}>
       <input {...getInputProps()} />
       {dropzoneIcon && <img className="mx-auto mb-8" src={dropzoneIcon} />}
-
       {error && <p className="max-w-lg text-scarlet-500 text-lg leading-none font-gilroy-bold mb-2">Error</p>}
       {fileTypeError && (
         <ErrorMessage
@@ -102,16 +98,9 @@ export const StyledDropZone: FunctionComponent<DropZoneProps> = ({
           message={`Upload too many documents at once, please upload a total of ${dropzoneOptions.maxFiles} document at a time.`}
         />
       )}
-      {fileErrors &&
-        fileErrors.length > 0 &&
-        fileErrors.map((formError, index: number) => {
-          return (
-            <ErrorMessage
-              key={`file-errors-${index}`}
-              id="file-error"
-              message={`${formError instanceof Error ? "" : formError.instancePath} ${formError.message}`}
-            />
-          );
+      {fileErrors.length > 0 &&
+        fileErrors.map((fileError, index: number) => {
+          return <ErrorMessage key={`file-errors-${index}`} id="file-error" message={fileError.message} />;
         })}
 
       <div className={error ? "mt-10" : ""}>{children}</div>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,6 +1,7 @@
 import { Wallet, Signer } from "ethers";
 import { Provider } from "@ethersproject/abstract-provider";
 import { OpenAttestationDocument } from "@govtechsg/open-attestation";
+import { ErrorObject } from "ajv";
 
 export type Network = "homestead" | "ropsten" | "rinkeby" | "local";
 type FormType = "TRANSFERABLE_RECORD" | "VERIFIABLE_DOCUMENT";
@@ -149,3 +150,5 @@ export interface NetworkObject {
     chainId: string;
   };
 }
+
+export type FormErrors = ErrorObject[] | null | undefined;


### PR DESCRIPTION
## Summary

Construct ajv errors with more hints.

## Changes

- Separate error handling.
- Show more hints of what error happened.

There are currently 2 kinds of error handling going on with the dropzones:

1. schema validate via ajv
2. custom file detect + custom error messages

If i'm understanding correctly, the above 2 became coupled at [here](https://github.com/TradeTrust/document-creator-website/blob/master/src/components/UI/StyledDropZone/StyledDropZone.tsx#L112). 

Moving forward, `FormErrorBanner` / `formErrors` will be used for ajv related errors, while `ErrorMessage` / `fileErrors` will be for file custom errors.

FYI: Looks like there is another option, with the help of additional [library](https://ajv.js.org/packages/ajv-errors.html) to handle errors at schema side instead 👀.

Before:
![b4](https://user-images.githubusercontent.com/4774314/181175188-ac638e59-ed06-4aa0-a42f-57c6c4fa5276.png)

After:
![after](https://user-images.githubusercontent.com/4774314/181175205-7bb146b3-43be-4918-880c-86f8e9bc237b.png)

## Issues

- https://www.pivotaltracker.com/story/show/182661933