### PR TITLE
fix: updated updateToStorage FN for local network

### DIFF
--- a/src/common/hook/useQueue/useQueue.tsx
+++ b/src/common/hook/useQueue/useQueue.tsx
@@ -6,8 +6,8 @@ import { revokeDocumentJob } from "../../../services/revoking";
 import { Config, FailedJobErrors, FormEntry, PublishingJob, RevokingJob, WrappedDocument } from "../../../types";
 import { getLogger } from "../../../utils/logger";
 import { uploadToStorage } from "../../API/storageAPI";
-import { getRevokingJobs } from "./utils/revoke";
 import { getPublishingJobs } from "./utils/publish";
+import { getRevokingJobs } from "./utils/revoke";
 
 const { stack } = getLogger("useQueue");
 
@@ -82,7 +82,7 @@ export const useQueue = ({
             }
             // upload all the docs to document storage
             const uploadDocuments = job.documents.map(async (doc) => {
-              if (config.documentStorage === undefined) return;
+              if (config.documentStorage === undefined || config.network === "local") return;
               await uploadToStorage(doc, config.documentStorage);
             });
             await Promise.all(uploadDocuments);

--- a/src/test/fixtures/config/test/config-invalid-issuer.json
+++ b/src/test/fixtures/config/test/config-invalid-issuer.json
@@ -27,10 +27,7 @@
       },
       "schema": {
         "type": "object",
-        "required": [
-          "blNumber",
-          "scac"
-        ],
+        "required": ["blNumber", "scac"],
         "properties": {
           "blNumber": {
             "type": "string",
@@ -579,9 +576,7 @@
       },
       "schema": {
         "type": "object",
-        "required": [
-          "documentName"
-        ],
+        "required": ["documentName"],
         "properties": {
           "documentName": {
             "type": "string",
@@ -758,7 +753,7 @@
               "location": "ErrorIdentityProof"
             },
             "name": "DEMO DOCUMENT STORE",
-            "documentStore": "0x63a223e025256790e88778a01f480eba77731d04"
+            "documentStore": "0x9Eb613a88534E2939518f4ffBFE65F5969b491FF"
           }
         ]
       },
@@ -1128,10 +1123,7 @@
           "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
           "https://schemata.openattestation.com/io/tradetrust/bill-of-lading/1.0/bill-of-lading-context.json"
         ],
-        "type": [
-          "VerifiableCredential",
-          "OpenAttestationCredential"
-        ],
+        "type": ["VerifiableCredential", "OpenAttestationCredential"],
         "issuanceDate": "2010-01-01T19:23:24Z",
         "openAttestationMetadata": {
           "template": {
@@ -1161,10 +1153,7 @@
         "properties": {
           "credentialSubject": {
             "type": "object",
-            "required": [
-              "blNumber",
-              "scac"
-            ],
+            "required": ["blNumber", "scac"],
             "properties": {
               "blNumber": {
                 "type": "string",
@@ -1270,10 +1259,7 @@
           "https://schemata.openattestation.com/io/tradetrust/certificate-of-origin/1.0/certificate-of-origin-context.json",
           "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json"
         ],
-        "type": [
-          "VerifiableCredential",
-          "OpenAttestationCredential"
-        ],
+        "type": ["VerifiableCredential", "OpenAttestationCredential"],
         "issuanceDate": "2010-01-01T19:23:24Z",
         "openAttestationMetadata": {
           "template": {
@@ -1728,10 +1714,7 @@
           "https://schemata.openattestation.com/io/tradetrust/Invoice/1.0/invoice-context.json",
           "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json"
         ],
-        "type": [
-          "VerifiableCredential",
-          "OpenAttestationCredential"
-        ],
+        "type": ["VerifiableCredential", "OpenAttestationCredential"],
         "issuanceDate": "2010-01-01T19:23:24Z",
         "openAttestationMetadata": {
           "template": {


### PR DESCRIPTION
## Summary

On local there is a bug where DID issue could not issue through the UI. This bug is due to the upload to storage api doesn't work on local, so the solution is to skip the upload to storage api on local.

## Changes

- Update updateToStorage function to skip on local network.

## Issues
https://www.pivotaltracker.com/n/projects/2424361/stories/182543737
