### PR TITLE
fix: document storage

### DIFF
--- a/src/common/API/storageAPI.tsx
+++ b/src/common/API/storageAPI.tsx
@@ -13,9 +13,12 @@ const getHeaders = (documentStorage: DocumentStorage): Headers => {
     "Content-Type": "application/json",
   } as Headers;
 
-  const apiKey = "x-api-key";
+  const xApiKey = "x-api-key";
 
-  if (documentStorage.apiKey) headers[apiKey] = documentStorage.apiKey;
+  if (documentStorage.apiKey)
+    headers[xApiKey] = process.env.REACT_APP_API_KEY_DOCUMENT_STORAGE
+      ? process.env.REACT_APP_API_KEY_DOCUMENT_STORAGE
+      : documentStorage.apiKey;
 
   return headers;
 };

--- a/src/common/hook/useQueue/utils/publish.tsx
+++ b/src/common/hook/useQueue/utils/publish.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../../types";
 import { getQueueNumber } from "../../../API/storageAPI";
 import { encodeQrCode, getDataV3, getDocumentNetwork } from "../../../utils";
+import { ChainInfo } from "../../../../constants/chainInfo";
 
 const redirectUrl = (network: Network) => {
   if (network === "homestead" || network === "matic") return "https://tradetrust.io/";
@@ -26,6 +27,7 @@ const redirectUrl = (network: Network) => {
 
 const getReservedStorageUrl = async (documentStorage: DocumentStorage, network: Network): Promise<ActionsUrlObject> => {
   const queueNumber = await getQueueNumber(documentStorage);
+  const chainObject = Object.values(ChainInfo).find((item) => item.networkName === network);
 
   const qrUrlObj = {
     type: "DOCUMENT",
@@ -34,6 +36,7 @@ const getReservedStorageUrl = async (documentStorage: DocumentStorage, network: 
       key: queueNumber.data.key,
       permittedActions: ["STORE"],
       redirect: redirectUrl(network),
+      chainId: `${chainObject?.chainId}`,
     },
   };
 

--- a/src/common/hook/useQueue/utils/sample-formatted.json
+++ b/src/common/hook/useQueue/utils/sample-formatted.json
@@ -26,7 +26,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%225%22%7D%7D"
         }
       }
     },
@@ -61,7 +61,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%225%22%7D%7D"
         }
       }
     },
@@ -101,7 +101,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%225%22%7D%7D"
         }
       }
     },
@@ -136,7 +136,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%225%22%7D%7D"
         }
       }
     },

--- a/src/common/hook/useQueue/utils/sample-formatted.json
+++ b/src/common/hook/useQueue/utils/sample-formatted.json
@@ -26,7 +26,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
         }
       }
     },
@@ -61,7 +61,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
         }
       }
     },
@@ -101,7 +101,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
         }
       }
     },
@@ -136,7 +136,7 @@
       },
       "links": {
         "self": {
-          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.example.com%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+          "href": "https://action.openattestation.com?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F123%22%2C%22key%22%3A%22123%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%2C%22chainId%22%3A%223%22%7D%7D"
         }
       }
     },


### PR DESCRIPTION
## Summary

- document storage service is down ([oa-functions](https://github.com/Open-Attestation/oa-functions))
  - oa-verify fails at storage upload (tied to ropsten)
  - therefore unable to encode `actions` url in `links.self.href` 
- eventually this results in qrcode feature in tradetrust web to be not working

## Changes

- redirect url should be either prod or dev, ever since "auto-network" feature
- added `chainId` value for `actions` handling

## Issues

- https://github.com/TradeTrust/tradetrust-website/pull/607
- https://github.com/TradeTrust/tradetrust-functions/pull/1
- https://github.com/TradeTrust/tradetrust-config/pull/27
