### PR TITLE
fix: schema allow network

### DIFF
--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -31,6 +31,7 @@ const configFileSchema = Joi.object({
         uiSchema: Joi.object(),
         extension: Joi.string(),
         fileName: Joi.string(),
+        network: Joi.object(),
       })
     )
     .required(),

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -126,7 +126,7 @@ export const getDataV3: any = (data: any) => {
  */
 const getDataV2: any = (data: any) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { issuers, $template, ownership, attachments, ...rest } = data; // omit these fields
+  const { issuers, $template, ownership, attachments, network, ...rest } = data; // omit these fields
   return rest;
 };
 
@@ -136,7 +136,7 @@ const getDataV2: any = (data: any) => {
  */
 const getData: any = (data: any) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { ownership, ...rest } = data; // omit these fields
+  const { ownership, network, ...rest } = data; // omit these fields
   return rest;
 };
 


### PR DESCRIPTION
## Summary

qr code not appearing for other networks, such as mumbai when using config generated from OA CLI

## Changes

- allow for `network` field

## Issues
- [fix/allow-other-network](https://github.com/Open-Attestation/open-attestation-cli/pull/250)
- https://www.pivotaltracker.com/story/show/183929424

