### PR TITLE
XDC Network details added.

### DIFF
--- a/src/common/config/validate.tsx
+++ b/src/common/config/validate.tsx
@@ -2,7 +2,7 @@ import Joi from "@hapi/joi";
 import { ConfigFile } from "../../types";
 
 const configFileSchema = Joi.object({
-  network: Joi.string().allow("homestead", "local", "goerli", "sepolia", "matic", "maticmum").only().required(),
+  network: Joi.string().allow("homestead", "local", "goerli", "sepolia", "matic", "maticmum","xdc","xdcapothem").only().required(),
   wallet: Joi.alternatives(
     Joi.string().required(),
     Joi.object().keys({

--- a/src/constants/chainInfo.tsx
+++ b/src/constants/chainInfo.tsx
@@ -30,6 +30,10 @@ export enum ChainId {
   // Polygon
   Polygon = 137,
   PolygonMumbai = 80001,
+
+  // XDC Network
+  XDC = 50,
+  XDCApothem=51,
 }
 
 export const ChainInfo: ChainInfo = {
@@ -96,6 +100,34 @@ export const ChainInfo: ChainInfo = {
     nativeCurrency: {
       name: "MATIC",
       symbol: "mMATIC",
+      decimals: 18,
+    },
+  },
+  [ChainId.XDC]: {
+    label: "XDC Network Mainnet",
+    chain: "XDC",
+    chainId: ChainId.XDC,
+    networkName: "xdc",
+    explorerUrl: "https://xdc.blocksscan.io",
+    explorerApiUrl: "https://xdc.blocksscan.io",
+    rpcUrl: "https://erpc.xinfin.network",
+    nativeCurrency: {
+      name: "XDC",
+      symbol: "XDC",
+      decimals: 18,
+    },
+  },
+  [ChainId.XDCApothem]: {
+    label: "XDC Testnet Apothem",
+    chain: "XDC",
+    chainId: ChainId.XDCApothem,
+    networkName: "xdcapothem",
+    explorerUrl: "https://apothem.blocksscan.io",
+    explorerApiUrl: "https://apothem.blocksscan.io",
+    rpcUrl: "https://erpc.apothem.network",
+    nativeCurrency: {
+      name: "XDCt",
+      symbol: "XDCt",
       decimals: 18,
     },
   },

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,7 +3,7 @@ import { OpenAttestationDocument } from "@govtechsg/open-attestation";
 import { ErrorObject } from "ajv";
 import { Signer, Wallet } from "ethers";
 
-export type Network = "homestead" | "goerli" | "local" | "sepolia" | "matic" | "maticmum";
+export type Network = "homestead" | "goerli" | "local" | "sepolia" | "matic" | "maticmum" | "xdc" | "xdcapothem";
 type FormType = "TRANSFERABLE_RECORD" | "VERIFIABLE_DOCUMENT";
 
 // FormTemplate is defined in configuration file


### PR DESCRIPTION
## Summary

### Added XDC Network MainNet & TestNet in TradeTrust Ecosystem
XinFin XDC.Network is an enterprise-ready hybrid Blockchain technology company optimised for international trade and finance. The XDC protocol is architected to support smart contracts, 2000TPS, 2 seconds transaction time, and KYC to Masternodes (Validator Nodes). The XDC.Network uses XinFin Delegated Proof of Stake (XDPoS), with the intention to create a ‘highly-scalable, secure, permission, and commercial grade blockchain network.

## Changes

We have added Apothem and Mainnet XDC network configuration as per the Trade Trust Requirement

